### PR TITLE
[Fix] Remove effect dependencies that cause unnecessary rerenders and requests

### DIFF
--- a/src/components/variables/VariablesList.tsx
+++ b/src/components/variables/VariablesList.tsx
@@ -14,6 +14,7 @@ interface VariablesListProps {
 const isListVariable = (variable: Variable): variable is ListVariable => variable.type === VariableType.list;
 
 function VariablesList({ variables, onMobileOptionListToggle, isDocumentLoaded }: VariablesListProps) {
+    console.log('variables', variables);
     const isMobileSize = useMobileSize();
     const [listVariableOpen, setListVariableOpen] = useState<ListVariable | null>(null);
 

--- a/src/components/variablesComponents/imageVariable/ImageVariable.tsx
+++ b/src/components/variablesComponents/imageVariable/ImageVariable.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { ImagePicker, Label } from '@chili-publish/grafx-shared-components';
 import { ImageVariable, Media, MediaDownloadType } from '@chili-publish/studio-sdk';
-import { ImagePicker, Label, usePreviewImage } from '@chili-publish/grafx-shared-components';
-import { IImageVariable } from '../VariablesComponents.types';
+import { useCallback, useEffect, useState } from 'react';
 import { useVariablePanelContext } from '../../../contexts/VariablePanelContext';
 import { getDataIdForSUI, getDataTestIdForSUI } from '../../../utils/dataIds';
+import { IImageVariable } from '../VariablesComponents.types';
+import usePreviewImage from './usePreviewStuff/usePreviewImage';
 
 function ImageVariable(props: IImageVariable) {
     const { variable, handleImageRemove } = props;
@@ -11,7 +12,7 @@ function ImageVariable(props: IImageVariable) {
     const [mediaDetails, setMediaDetails] = useState<Media | null>(null);
     const { showImagePanel, connectorCapabilities, getCapabilitiesForConnector } = useVariablePanelContext();
 
-    const previewCall = async (id: string) => {
+    const previewCall = useCallback(async (id: string) => {
         let response = { success: true };
         const downloadCall = async () => {
             return window.SDK.mediaConnector.download(
@@ -22,6 +23,7 @@ function ImageVariable(props: IImageVariable) {
             );
         };
         try {
+            console.log('previewCall');
             return downloadCall();
         } catch {
             const mediaConnectorState = await window.SDK.connector.getState(variable.value?.connectorId ?? '');
@@ -33,9 +35,10 @@ function ImageVariable(props: IImageVariable) {
             }
             return null;
         }
-    };
+    }, []);
 
     useEffect(() => {
+        console.log('useEffect');
         async function getMediaDetails() {
             if (!variable.value || !variable.value.connectorId) return;
 
@@ -63,7 +66,13 @@ function ImageVariable(props: IImageVariable) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const { previewImage } = usePreviewImage(mediaDetails, previewCall, true, variable);
+    const { previewImage } = usePreviewImage(
+        mediaDetails,
+        previewCall,
+        true,
+        variable.value?.assetId ?? '',
+        variable.name,
+    );
 
     return (
         <ImagePicker

--- a/src/components/variablesComponents/imageVariable/usePreviewStuff/usePreviewImage.ts
+++ b/src/components/variablesComponents/imageVariable/usePreviewStuff/usePreviewImage.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from 'react';
+
+export function isEmpty(value: unknown) {
+    return (
+        value == null ||
+        (Object.prototype.hasOwnProperty.call(value, 'length') && (value as unknown[] | string).length === 0) ||
+        ((value as Record<string, unknown>).constructor === Object &&
+            Object.keys(value as Record<string, unknown>).length === 0)
+    );
+}
+
+type GenericVariableType = {
+    id?: any;
+    name?: any;
+    value?: {
+        assetId: string;
+        connectorId: string;
+    };
+};
+
+type GenericMediaType = {
+    id?: string;
+    name?: string;
+    extension?: string | null;
+};
+
+type GenericPreviewImageType = { id?: string; url?: string; name?: string; format?: string | null };
+
+function usePreviewImage(
+    mediaDetails: GenericMediaType | null,
+    previewCall: (id: string) => Promise<Uint8Array | null>,
+    isPanelOpen: boolean,
+    variableAssetId: string,
+    variableName: string,
+    defaultImageFormat = 'PNG',
+) {
+    const [previewImage, setPreviewImage] = useState<GenericPreviewImageType>();
+
+    // This useEffect decodes the image previews inside the ImagePicker
+    useEffect(() => {
+        if (!isPanelOpen) return;
+        if (isEmpty(mediaDetails)) return;
+
+        const getPreviewCall = async (assetId: string) => {
+            // eslint-disable-next-line no-extra-boolean-cast
+            if (!!previewCall) {
+                const response = await previewCall(assetId);
+                return response;
+            }
+            return null;
+        };
+
+        const setPreview = async () => {
+            let url: string;
+
+            if (variableAssetId) {
+                const response = await getPreviewCall(variableAssetId);
+                if (response instanceof Uint8Array) {
+                    const blob = new Blob([response]);
+                    url = URL.createObjectURL(blob);
+                }
+            }
+
+            return setPreviewImage((foundPreviewImage) => {
+                let updatedPreviewImage;
+
+                // If image was removed from imagePicker and later reassigned.
+                if (url) {
+                    return {
+                        id: mediaDetails?.id,
+                        name: mediaDetails?.name,
+                        format: mediaDetails?.extension?.toUpperCase() || defaultImageFormat,
+                        url,
+                    };
+                }
+
+                if (!url) {
+                    return undefined;
+                }
+
+                // Do not show imagePreview if `value` property is missing (the image was removed).
+                if (!variableAssetId) {
+                    updatedPreviewImage = undefined;
+                } else {
+                    // Update the imagePreview with the correct values and add fallbacks. This means, that
+                    // the imagePreview got its URL updated (new image was assigned). If image name is not accessible
+                    // fallback to the variable name. If the format is not accessible,
+                    // fallback to the defaultImageFormat - PNG. This will be fixed later.
+                    updatedPreviewImage = {
+                        ...foundPreviewImage,
+                        name: foundPreviewImage?.name ?? variableName,
+                        format: foundPreviewImage?.format ?? defaultImageFormat,
+                        url,
+                    };
+                }
+                return updatedPreviewImage;
+            });
+        };
+
+        if (!variableAssetId) {
+            setPreviewImage(undefined);
+            return;
+        }
+        setPreview();
+        // After successful API call to change the image, the Variable `src` property
+        // should be then changed, allowing for this useEffect to be fired once again.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isPanelOpen, variableAssetId, variableName, mediaDetails?.id]);
+
+    return {
+        previewImage,
+    };
+}
+
+export default usePreviewImage;


### PR DESCRIPTION
This PR removes dependencies from useEffect in ImageVariable.tsx component, thus removing unnecessary requests for the image previews

## Related tickets

-   [WRS-1369](https://chilipublishintranet.atlassian.net/browse/WRS-1369)

## Screenshots


[WRS-1369]: https://chilipublishintranet.atlassian.net/browse/WRS-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ