### PR TITLE
[Fix] Pass the editorLink properly on GraFx Platform

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -82,6 +82,7 @@ export default class StudioUI {
             extension: string,
             selectedLayoutID: string | undefined,
         ) => Promise<DownloadLinkResult>,
+        editorLink?: string,
     ) {
         return new StudioUI(selector, {
             projectId,
@@ -95,6 +96,7 @@ export default class StudioUI {
             onUserInterfaceBack,
             onLogInfoRequested,
             onProjectGetDownloadLink,
+            overrideEngineUrl: editorLink,
         });
     }
 
@@ -121,6 +123,7 @@ export default class StudioUI {
         refreshTokenAction: () => Promise<string | AxiosError>,
         projectName: string,
         onBack: () => void,
+        editorLink?: string,
     ) {
         const projectLoader = new StudioProjectLoader(
             projectId,
@@ -144,6 +147,7 @@ export default class StudioUI {
             onBack,
             projectLoader.onLogInfoRequested,
             projectLoader.onProjectGetDownloadLink,
+            editorLink,
         );
     }
 


### PR DESCRIPTION
On platform, we still relied on passing the editorLink as before

![image](https://github.com/chili-publish/studio-ui/assets/956362/eefd2589-dcaf-47f2-b837-d495692aa5d8)

Re-added this capability to the new studio-ui init code

Abusing [WRS-1345](https://chilipublishintranet.atlassian.net/browse/WRS-1345) as remotely related ticket to satisfy CICD

[WRS-1345]: https://chilipublishintranet.atlassian.net/browse/WRS-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ