### PR TITLE
[Fix] commit hash sent as null on dev

### DIFF
--- a/src/utils/documentExportHelper.ts
+++ b/src/utils/documentExportHelper.ts
@@ -55,9 +55,10 @@ export const getDownloadLink = async (
             if (format !== DownloadFormats.PDF) {
                 generateExportUrl += `&engineVersion=${engineVersion}`;
                 if (engineCommitSha) generateExportUrl += `-${engineCommitSha}`;
+            } else {
+                pdfBody.engineVersion = `${engineVersion}`;
+                if (engineCommitSha) pdfBody.engineVersion += `-${engineCommitSha}`;
             }
-
-            pdfBody.engineVersion = `${engineVersion}${engineCommitSha && `-${engineCommitSha}`}`;
         }
 
         const config: HttpHeaders = {


### PR DESCRIPTION
This PR Fixes the issue of sending commit hash as `null`, in case of choosing a released version of the engine, the engine version is sent like this `1.6.1null`, this PR makes sure that we don't send the hash if a released version is chosen.
Note this can happen only in dev as on prod we don't use commit hash

## Related tickets

-   [WRS-NUMBER](https://chilipublishintranet.atlassian.net/browse/WRS-NUMBER)

## Screenshots
