### PR TITLE
[Fix] [WRS-2011] Set hand tool without document

### DIFF
--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -246,6 +246,7 @@ function MainContent({ projectConfig, authToken, updateToken: setAuthToken }: Ma
         const setHandTool = async () => {
             await window.SDK.tool.setHand();
         };
+        setHandTool();
         const loadDocument = async () => {
             if (authToken) {
                 await window.SDK.configuration.setValue(WellKnownConfigurationKeys.GraFxStudioAuthToken, authToken);
@@ -271,7 +272,6 @@ function MainContent({ projectConfig, authToken, updateToken: setAuthToken }: Ma
             const layoutIntentData = (await window.SDK.layout.getSelected()).parsedData?.intent.value || null;
             setLayoutIntent(layoutIntentData);
 
-            setHandTool();
             zoomToPage();
         };
 

--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -244,9 +244,7 @@ function MainContent({ projectConfig, authToken, updateToken: setAuthToken }: Ma
 
     useEffect(() => {
         const setHandTool = async () => {
-            if (fetchedDocument) {
-                await window.SDK.tool.setHand();
-            }
+            await window.SDK.tool.setHand();
         };
         const loadDocument = async () => {
             if (authToken) {


### PR DESCRIPTION
This PR Sets hand tool without waiting to load the document, to prevent getting the pointer because in that case user can select frames.

## Related tickets

-   [WRS-2011](https://chilipublishintranet.atlassian.net/browse/WRS-2011)

## Screenshots


[WRS-2011]: https://chilipublishintranet.atlassian.net/browse/WRS-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ