### PR TITLE
[Fix][WRS-2298] Read connector options from linked variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "react-select-event": "^5.5.1",
         "resize-observer-polyfill": "^1.5.1",
         "ts-jest": "^29.1.0",
-        "typescript": "*",
+        "typescript": "^5.7.3",
         "vite": "^4.3.9",
         "vite-plugin-environment": "^1.1.3"
     },

--- a/src/components/pagesPanel/Pages.tsx
+++ b/src/components/pagesPanel/Pages.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Page } from '@chili-publish/studio-sdk';
 import {
     PreviewCard,
     PreviewCardVariant,
@@ -7,12 +5,14 @@ import {
     ScrollbarWrapper,
     useMobileSize,
 } from '@chili-publish/grafx-shared-components';
-import { ScrollableContainer, Card, Container } from './Pages.styles';
-import { BORDER_SIZE, PAGES_CONTAINER_HEIGHT, PREVIEW_FALLBACK } from '../../utils/constants';
+import { Page } from '@chili-publish/studio-sdk';
+import { useCallback, useEffect, useState } from 'react';
+import { useUiConfigContext } from '../../contexts/UiConfigContext';
 import { PageSnapshot } from '../../types/types';
+import { BORDER_SIZE, PAGES_CONTAINER_HEIGHT, PREVIEW_FALLBACK } from '../../utils/constants';
+import { Card, Container, ScrollableContainer } from './Pages.styles';
 import { PreviewCardBadge } from './PreviewCardBadge';
 import { useAttachArrowKeysListener } from './useAttachArrowKeysListener';
-import { useUiConfigContext } from '../../contexts/UiConfigContext';
 
 interface PagesProps {
     pages: Page[];
@@ -105,7 +105,9 @@ function Pages({ pages, activePageId, pagesToRefresh, setPagesToRefresh }: Pages
                                         path={
                                             pageSnapshots[index] &&
                                             URL.createObjectURL(
-                                                new Blob([pageSnapshots[index].snapshot.buffer], { type: 'image/png' }),
+                                                new Blob([pageSnapshots[index].snapshot.buffer as BlobPart], {
+                                                    type: 'image/png',
+                                                }),
                                             )
                                         }
                                         type={PreviewType.IMAGE}

--- a/src/components/variablesComponents/imageVariable/useMediaDetails.ts
+++ b/src/components/variablesComponents/imageVariable/useMediaDetails.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
 import { ConnectorMappingDirection, ConnectorStateType, Media } from '@chili-publish/studio-sdk';
+import { useCallback, useEffect, useState } from 'react';
 import { useVariablePanelContext } from '../../../contexts/VariablePanelContext';
 import { useVariablesChange } from '../../../core/hooks/useVariablesChange';
+import { fromLinkToVariableId, isLinkToVariable } from '../../../utils/connectors';
 
 export const useMediaDetails = (connectorId: string | undefined, mediaAssetId: string | undefined) => {
     const { connectorCapabilities, getCapabilitiesForConnector } = useVariablePanelContext();
@@ -47,11 +48,13 @@ export const useMediaDetails = (connectorId: string | undefined, mediaAssetId: s
             if (!connectorId || mediaConnectorState === null) {
                 return;
             }
-            const mappings = await window.StudioUISDK.connector.getMappings(connectorId);
+            const mappings = await window.StudioUISDK.connector.getMappings(
+                connectorId,
+                ConnectorMappingDirection.engineToConnector,
+            );
             const variableIds = mappings.parsedData
-                ?.filter((m) => m.direction === ConnectorMappingDirection.engineToConnector)
-                .filter((m) => typeof m.value === 'string' && m.value.startsWith('var.'))
-                .map((m) => (m.value as string).replace('var.', ''));
+                ?.filter((m) => isLinkToVariable(m))
+                .map((m) => fromLinkToVariableId(m.value));
             setVariableIdsInMapping(variableIds ?? []);
         })();
     }, [connectorId, mediaConnectorState]);

--- a/src/tests/components/variablesComponents/imageVariable/useMediaDetails.test.ts
+++ b/src/tests/components/variablesComponents/imageVariable/useMediaDetails.test.ts
@@ -105,7 +105,12 @@ describe('"useMediaDetails" hook', () => {
 
         expect(window.StudioUISDK.connector.waitToBeReady).not.toHaveBeenCalledWith('grafx-media');
 
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
         await waitFor(() => expect(getCapabilitiesForConnector).toHaveBeenCalledWith('grafx-media'));
 
         expect(window.StudioUISDK.mediaConnector.query).not.toHaveBeenCalled();
@@ -127,7 +132,12 @@ describe('"useMediaDetails" hook', () => {
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
 
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         expect(getCapabilitiesForConnector).not.toHaveBeenCalledWith('grafx-media');
         expect(window.StudioUISDK.mediaConnector.query).not.toHaveBeenCalled();
@@ -150,7 +160,12 @@ describe('"useMediaDetails" hook', () => {
         renderHook(() => useMediaDetails('grafx-media', 'media-asset-id'));
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         const variableChange = { id: '7377E97A-5FD9-46B1-A8CF-0C7C776C7DC2', value: '1234' } as unknown as Variable;
         mockSubscriber.emit('onVariableListChanged', [variableChange]);
@@ -176,7 +191,12 @@ describe('"useMediaDetails" hook', () => {
         renderHook(() => useMediaDetails('grafx-media', 'media-asset-id'));
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         const variableChange = { id: '2', value: '1234' } as unknown as Variable;
         mockSubscriber.emit('onVariableListChanged', [variableChange]);
@@ -202,7 +222,12 @@ describe('"useMediaDetails" hook', () => {
         const { result } = renderHook(() => useMediaDetails('grafx-media', 'media-asset-id'));
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         const variableChange = { id: '8A59BB89-898D-4BAC-9C8F-F40F6C83479E', value: '1234' } as unknown as Variable;
         mockSubscriber.emit('onVariableListChanged', [variableChange]);
@@ -233,7 +258,12 @@ describe('"useMediaDetails" hook', () => {
         const { result } = renderHook(() => useMediaDetails('grafx-media', 'media-asset-id'));
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         const variableChange = { id: '8A59BB89-898D-4BAC-9C8F-F40F6C83479E', value: '1234' } as unknown as Variable;
         mockSubscriber.emit('onVariableListChanged', [variableChange]);
@@ -271,7 +301,12 @@ describe('"useMediaDetails" hook', () => {
         const { result } = renderHook(() => useMediaDetails('grafx-media', 'media-asset-id'));
 
         await waitFor(() => expect(window.StudioUISDK.connector.getState).toHaveBeenCalledWith('grafx-media'));
-        await waitFor(() => expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith('grafx-media'));
+        await waitFor(() =>
+            expect(window.StudioUISDK.connector.getMappings).toHaveBeenCalledWith(
+                'grafx-media',
+                ConnectorMappingDirection.engineToConnector,
+            ),
+        );
 
         const variableChange = { id: '8A59BB89-898D-4BAC-9C8F-F40F6C83479E', value: '1234' } as unknown as Variable;
         await act(() => {

--- a/src/tests/utils/connectors.test.ts
+++ b/src/tests/utils/connectors.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import EditorSDK, { ConnectorMappingDirection } from '@chili-publish/studio-sdk';
+import EditorSDK, { ConnectorMappingDirection, VariableType } from '@chili-publish/studio-sdk';
 import axios from 'axios';
 import { mock } from 'jest-mock-extended';
 import {
@@ -16,6 +16,7 @@ const GRAFX_ENV_API = 'http://env-1.com/';
 describe('utils connectors', () => {
     const mockSDK = mock<EditorSDK>();
     mockSDK.next.connector = {} as any;
+    mockSDK.next.variable = {} as any;
 
     mockSDK.next.connector.getById = jest.fn().mockResolvedValue({
         parsedData: {
@@ -23,7 +24,7 @@ describe('utils connectors', () => {
         },
     });
     mockSDK.mediaConnector.query = jest.fn();
-    mockSDK.variable.getById = jest.fn();
+    mockSDK.next.variable.getById = jest.fn();
     mockSDK.connector.getMappings = jest.fn();
 
     window.StudioUISDK = mockSDK;
@@ -83,15 +84,30 @@ describe('utils connectors', () => {
     });
 
     it('should "getConnectorConfigurationOptions" correctly', async () => {
-        (mockSDK.variable.getById as jest.Mock)
+        (mockSDK.next.variable.getById as jest.Mock)
             .mockResolvedValueOnce({
                 parsedData: {
                     value: 'text',
+                    type: VariableType.shortText,
                 },
             })
             .mockResolvedValueOnce({
                 parsedData: {
                     value: false,
+                    type: VariableType.boolean,
+                },
+            })
+            .mockResolvedValueOnce({
+                parsedData: {
+                    selected: {
+                        value: 'list-item-1',
+                    },
+                    type: VariableType.list,
+                },
+            })
+            .mockResolvedValueOnce({
+                parsedData: {
+                    type: VariableType.list,
                 },
             });
 
@@ -113,6 +129,14 @@ describe('utils connectors', () => {
                     name: 'option-4',
                     value: 'var.var2',
                 },
+                {
+                    name: 'option-5',
+                    value: 'var.var3',
+                },
+                {
+                    name: 'option-6',
+                    value: 'var.var4',
+                },
             ],
         });
 
@@ -127,6 +151,8 @@ describe('utils connectors', () => {
             'option-2': 'text',
             'option-3': true,
             'option-4': false,
+            'option-5': 'list-item-1',
+            'option-6': null,
         });
     });
 });

--- a/src/tests/utils/documentExportHelper.test.tsx
+++ b/src/tests/utils/documentExportHelper.test.tsx
@@ -127,9 +127,11 @@ describe('"getDownloadLink', () => {
             );
         });
 
-        it('should skip sending data source output type is not "Batch"', async () => {
+        it('should skip sending data source if output setting does not have "dataSourceEnabled"', async () => {
             (axios.get as jest.Mock).mockResolvedValue({
-                data: {},
+                data: {
+                    dataSourceEnabled: false,
+                },
             });
             await getDownloadLink(DownloadFormats.PDF, '', 'Token', '1', 'projectId', 'outputId', false);
 

--- a/src/types/OutputGenerationTypes.ts
+++ b/src/types/OutputGenerationTypes.ts
@@ -1,6 +1,6 @@
 export type DataConnectorConfiguration = {
     dataConnectorId: string;
     dataConnectorParameters: {
-        context: Record<string, string | boolean> | null;
+        context: Record<string, string | boolean | null> | null;
     };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6262,10 +6262,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@*:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Before sending request for batch output, we should read the actual connector configuration options if there is a mapping created as "linkToVariable"

## Related tickets

-   [WRS-2298](https://chilipublishintranet.atlassian.net/browse/WRS-2298)

## Screenshots


[WRS-2298]: https://chilipublishintranet.atlassian.net/browse/WRS-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ