### PR TITLE
[Fix][WRS-2313] Add possibility to hide layout section and layout switcher

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -65,32 +65,32 @@ jobs:
                   inlineScript: |
                       az storage blob upload-batch -d studio-ui -s upload/ --connection-string "${{ secrets.AZURE_CDN_STUDIO_PRD_CONNECTION_STRING }}" --overwrite true
 
-    # bump-version:
-    #     needs: build
-    #     runs-on: ubuntu-latest
-    #     strategy:
-    #         matrix:
-    #             node-version: [20]
-    #     steps:
-    #         - uses: FranzDiebold/github-env-vars-action@v2
-    #         - uses: actions/checkout@v3
-    #           with:
-    #               token: ${{ secrets.PACKAGE_SECRET }}
-    #         - name: Use Node ${{ matrix.node-version }}
-    #           uses: actions/setup-node@v3
-    #           with:
-    #               node-version: ${{ matrix.node-version }}
-    #               registry-url: 'https://npm.pkg.github.com'
-    #               scope: '@chili-publish'
-    #         - name: Bump version
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #           run: |
-    #               git config --global user.name 'github-actions[bot]'
-    #               git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-    #               git fetch origin
-    #               git checkout -B main origin/main
-    #               npm version preminor --no-git-tag-version
-    #               git add package.json yarn.lock
-    #               git commit -m "CI: Bump version to $(jq -r .version < package.json) [skip ci]" --allow-empty
-    #               git push origin main --follow-tags
+    bump-version:
+        needs: build
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20]
+        steps:
+            - uses: FranzDiebold/github-env-vars-action@v2
+            - uses: actions/checkout@v3
+              with:
+                  token: ${{ secrets.PACKAGE_SECRET }}
+            - name: Use Node ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  registry-url: 'https://npm.pkg.github.com'
+                  scope: '@chili-publish'
+            - name: Bump version
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  git fetch origin
+                  git checkout -B main origin/main
+                  npm version preminor --no-git-tag-version
+                  git add package.json yarn.lock
+                  git commit -m "CI: Bump version to $(jq -r .version < package.json) [skip ci]" --allow-empty
+                  git push origin main --follow-tags

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -65,32 +65,32 @@ jobs:
                   inlineScript: |
                       az storage blob upload-batch -d studio-ui -s upload/ --connection-string "${{ secrets.AZURE_CDN_STUDIO_PRD_CONNECTION_STRING }}" --overwrite true
 
-    bump-version:
-        needs: build
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                node-version: [20]
-        steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v3
-              with:
-                  token: ${{ secrets.PACKAGE_SECRET }}
-            - name: Use Node ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  registry-url: 'https://npm.pkg.github.com'
-                  scope: '@chili-publish'
-            - name: Bump version
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  git config --global user.name 'github-actions[bot]'
-                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-                  git fetch origin
-                  git checkout -B main origin/main
-                  npm version preminor --no-git-tag-version
-                  git add package.json yarn.lock
-                  git commit -m "CI: Bump version to $(jq -r .version < package.json) [skip ci]" --allow-empty
-                  git push origin main --follow-tags
+    # bump-version:
+    #     needs: build
+    #     runs-on: ubuntu-latest
+    #     strategy:
+    #         matrix:
+    #             node-version: [20]
+    #     steps:
+    #         - uses: FranzDiebold/github-env-vars-action@v2
+    #         - uses: actions/checkout@v3
+    #           with:
+    #               token: ${{ secrets.PACKAGE_SECRET }}
+    #         - name: Use Node ${{ matrix.node-version }}
+    #           uses: actions/setup-node@v3
+    #           with:
+    #               node-version: ${{ matrix.node-version }}
+    #               registry-url: 'https://npm.pkg.github.com'
+    #               scope: '@chili-publish'
+    #         - name: Bump version
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #           run: |
+    #               git config --global user.name 'github-actions[bot]'
+    #               git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+    #               git fetch origin
+    #               git checkout -B main origin/main
+    #               npm version preminor --no-git-tag-version
+    #               git add package.json yarn.lock
+    #               git commit -m "CI: Bump version to $(jq -r .version < package.json) [skip ci]" --allow-empty
+    #               git push origin main --follow-tags

--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -26,7 +26,9 @@ import {
 } from './components/connector-authentication';
 import HtmlRenderer from './components/htmlRenderer/HtmlRenderer';
 import LeftPanel from './components/layout-panels/leftPanel/LeftPanel';
+import LoadDocumentErrorDialog from './components/load-document-error/LoadDocumentErrorDialog';
 import Navbar from './components/navbar/Navbar';
+import { OutputSettingsContextProvider } from './components/navbar/OutputSettingsContext';
 import StudioNavbar from './components/navbar/studioNavbar/StudioNavbar';
 import Pages from './components/pagesPanel/Pages';
 import MobileVariablesTray from './components/variables/MobileVariablesTray';
@@ -40,8 +42,6 @@ import { SuiCanvas } from './MainContent.styles';
 import { Project, ProjectConfig } from './types/types';
 import { APP_WRAPPER_ID } from './utils/constants';
 import { getDataIdForSUI, getDataTestIdForSUI } from './utils/dataIds';
-import LoadDocumentErrorDialog from './components/load-document-error/LoadDocumentErrorDialog';
-import { OutputSettingsContextProvider } from './components/navbar/OutputSettingsContext';
 
 declare global {
     interface Window {
@@ -390,6 +390,11 @@ function MainContent({ projectConfig, updateToken: setAuthToken }: MainContentPr
         [currentProject?.name, projectConfig, undoStackState, currentZoom],
     );
 
+    const layoutSectionUIOptions = {
+        visible: !multiLayoutMode && !!projectConfig.uiOptions.widgets?.layoutSection?.visible,
+        title: projectConfig.uiOptions.widgets?.layoutSection?.title ?? 'Layout',
+    };
+
     return (
         <AppProvider isDocumentLoaded={isDocumentLoaded} isAnimationPlaying={animationStatus} dataSource={dataSource}>
             <ShortcutProvider projectConfig={projectConfig} undoStackState={undoStackState} zoom={currentZoom}>
@@ -427,6 +432,7 @@ function MainContent({ projectConfig, updateToken: setAuthToken }: MainContentPr
                                             selectedLayout={currentSelectedLayout}
                                             layouts={layouts}
                                             layoutPropertiesState={layoutPropertiesState}
+                                            layoutSectionUIOptions={layoutSectionUIOptions}
                                             activePageDetails={
                                                 pages.find((page) => page.id === activePageId) ?? undefined
                                             }
@@ -439,6 +445,7 @@ function MainContent({ projectConfig, updateToken: setAuthToken }: MainContentPr
                                                 layouts={layouts}
                                                 variables={variables}
                                                 layoutPropertiesState={layoutPropertiesState}
+                                                layoutSectionUIOptions={layoutSectionUIOptions}
                                                 activePageDetails={
                                                     pages.find((page) => page.id === activePageId) ?? undefined
                                                 }

--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -391,8 +391,9 @@ function MainContent({ projectConfig, updateToken: setAuthToken }: MainContentPr
     );
 
     const layoutSectionUIOptions = {
-        visible: !multiLayoutMode && !!projectConfig.uiOptions.widgets?.layoutSection?.visible,
-        title: projectConfig.uiOptions.widgets?.layoutSection?.title ?? 'Layout',
+        visible: !multiLayoutMode,
+        layoutSwitcherVisible: !!projectConfig.uiOptions.layoutSection?.layoutSwitcherVisible,
+        title: projectConfig.uiOptions.layoutSection?.title ?? 'Layout',
     };
 
     return (

--- a/src/_dev-execution/bootstrap.ts
+++ b/src/_dev-execution/bootstrap.ts
@@ -80,13 +80,18 @@ import { TokenManager } from './token-manager';
             widgets: {
                 backButton: { visible: true },
                 navBar: { visible: true },
-                bottomBar: { visible: true },
+                bottomBar: { visible: false },
                 downloadButton: { visible: true },
+            },
+            layoutSection: {
+                layoutSwitcherVisible: true,
+                title: 'Layout',
             },
         },
         featureFlags: {
             studioDataSource: true,
         },
+        onSetMultiLayout: (setter) => setter(true),
         // eslint-disable-next-line no-console
         onVariableFocus: (id) => console.log('focused var: ', id),
         // eslint-disable-next-line no-console

--- a/src/_dev-execution/bootstrap.ts
+++ b/src/_dev-execution/bootstrap.ts
@@ -91,7 +91,6 @@ import { TokenManager } from './token-manager';
         featureFlags: {
             studioDataSource: true,
         },
-        onSetMultiLayout: (setter) => setter(true),
         // eslint-disable-next-line no-console
         onVariableFocus: (id) => console.log('focused var: ', id),
         // eslint-disable-next-line no-console

--- a/src/components/layout-panels/leftPanel/LeftPanel.tsx
+++ b/src/components/layout-panels/leftPanel/LeftPanel.tsx
@@ -4,13 +4,14 @@ import { useMemo } from 'react';
 import { useFeatureFlagContext } from '../../../contexts/FeatureFlagProvider';
 import { useVariablePanelContext } from '../../../contexts/VariablePanelContext';
 import { ContentType } from '../../../contexts/VariablePanelContext.types';
+import { UiOptions } from '../../../types/types';
 import DataSource from '../../dataSource/DataSource';
 import ImagePanel from '../../imagePanel/ImagePanel';
-import VariablesList from '../../variables/VariablesList';
-import { ImagePanelContainer, LeftPanelWrapper, LeftPanelContainer } from './LeftPanel.styles';
-import AvailableLayouts from './AvailableLayouts';
-import { PanelTitle } from '../../shared/Panel.styles';
 import LayoutProperties from '../../LayoutPanel/LayoutProperties';
+import { PanelTitle } from '../../shared/Panel.styles';
+import VariablesList from '../../variables/VariablesList';
+import AvailableLayouts from './AvailableLayouts';
+import { ImagePanelContainer, LeftPanelContainer, LeftPanelWrapper } from './LeftPanel.styles';
 
 interface LeftPanelProps {
     variables: Variable[];
@@ -18,22 +19,32 @@ interface LeftPanelProps {
     selectedLayout: Layout | null;
     layouts: LayoutListItemType[];
     layoutPropertiesState: LayoutPropertiesType;
+    layoutSectionUIOptions: Required<Required<Required<UiOptions>['widgets']>['layoutSection']>;
     activePageDetails?: Page;
 }
 
-function LeftPanel({ variables, selectedLayout, layouts, layoutPropertiesState, activePageDetails }: LeftPanelProps) {
+function LeftPanel({
+    variables,
+    selectedLayout,
+    layouts,
+    layoutPropertiesState,
+    activePageDetails,
+    layoutSectionUIOptions,
+}: LeftPanelProps) {
     const { contentType } = useVariablePanelContext();
     const { featureFlags } = useFeatureFlagContext();
     const availableLayouts = useMemo(() => layouts.filter((item) => item.availableForUser), [layouts]);
+    const isAvailableLayoutsDisplayed =
+        layoutSectionUIOptions.visible &&
+        (availableLayouts.length >= 2 || !!(selectedLayout?.id && selectedLayout?.resizableByUser.enabled));
     return (
         <LeftPanelWrapper id="left-panel" overflowScroll={contentType !== ContentType.IMAGE_PANEL}>
             <ScrollbarWrapper data-intercom-target="Customize panel">
                 <LeftPanelContainer hidden={contentType === ContentType.IMAGE_PANEL}>
                     {featureFlags?.studioDataSource ? <DataSource /> : null}
-                    {(availableLayouts.length >= 2 ||
-                        (selectedLayout?.id && selectedLayout?.resizableByUser.enabled)) && (
+                    {isAvailableLayoutsDisplayed && (
                         <>
-                            <PanelTitle>Layout</PanelTitle>
+                            <PanelTitle>{layoutSectionUIOptions.title}</PanelTitle>
                             {availableLayouts.length >= 2 && (
                                 <AvailableLayouts
                                     selectedLayout={selectedLayout}

--- a/src/components/layout-panels/leftPanel/LeftPanel.tsx
+++ b/src/components/layout-panels/leftPanel/LeftPanel.tsx
@@ -19,7 +19,7 @@ interface LeftPanelProps {
     selectedLayout: Layout | null;
     layouts: LayoutListItemType[];
     layoutPropertiesState: LayoutPropertiesType;
-    layoutSectionUIOptions: Required<Required<Required<UiOptions>['widgets']>['layoutSection']>;
+    layoutSectionUIOptions: Required<Required<UiOptions>['layoutSection']> & { visible: boolean };
     activePageDetails?: Page;
 }
 
@@ -34,9 +34,11 @@ function LeftPanel({
     const { contentType } = useVariablePanelContext();
     const { featureFlags } = useFeatureFlagContext();
     const availableLayouts = useMemo(() => layouts.filter((item) => item.availableForUser), [layouts]);
+
+    const isLayoutSwitcherVisible = availableLayouts.length >= 2 && layoutSectionUIOptions.layoutSwitcherVisible;
+    const isLayoutResizableVisible = !!(selectedLayout?.id && selectedLayout?.resizableByUser.enabled);
     const isAvailableLayoutsDisplayed =
-        layoutSectionUIOptions.visible &&
-        (availableLayouts.length >= 2 || !!(selectedLayout?.id && selectedLayout?.resizableByUser.enabled));
+        layoutSectionUIOptions.visible && (isLayoutSwitcherVisible || isLayoutResizableVisible);
     return (
         <LeftPanelWrapper id="left-panel" overflowScroll={contentType !== ContentType.IMAGE_PANEL}>
             <ScrollbarWrapper data-intercom-target="Customize panel">
@@ -45,13 +47,13 @@ function LeftPanel({
                     {isAvailableLayoutsDisplayed && (
                         <>
                             <PanelTitle>{layoutSectionUIOptions.title}</PanelTitle>
-                            {availableLayouts.length >= 2 && (
+                            {isLayoutSwitcherVisible && (
                                 <AvailableLayouts
                                     selectedLayout={selectedLayout}
                                     availableForUserLayouts={availableLayouts}
                                 />
                             )}
-                            {selectedLayout?.id && selectedLayout?.resizableByUser.enabled && (
+                            {isLayoutResizableVisible && (
                                 <LayoutProperties
                                     layout={layoutPropertiesState}
                                     activePageDetails={activePageDetails}

--- a/src/components/variables/MobileTrayHeader.tsx
+++ b/src/components/variables/MobileTrayHeader.tsx
@@ -1,16 +1,18 @@
 import { AvailableIcons, Button, ButtonVariant, Icon } from '@chili-publish/grafx-shared-components';
 import { css } from 'styled-components';
+import { useVariablePanelContext } from '../../contexts/VariablePanelContext';
 import { ContentType } from '../../contexts/VariablePanelContext.types';
 import { DatePickerTrayTitle, TrayPanelTitle } from './VariablesPanel.styles';
-import { useVariablePanelContext } from '../../contexts/VariablePanelContext';
 
 interface MobileTrayHeaderProps {
+    layoutSectionTitle: string;
     isDefaultPanelView: boolean;
     mobileListOpen: boolean;
     isDataSourceDisplayed: boolean;
     isAvailableLayoutsDisplayed: boolean;
 }
 function MobileTrayHeader({
+    layoutSectionTitle,
     isDefaultPanelView,
     mobileListOpen,
     isDataSourceDisplayed,
@@ -19,7 +21,7 @@ function MobileTrayHeader({
     const { contentType, showVariablesPanel, imagePanelTitle } = useVariablePanelContext();
 
     if (isDefaultPanelView && isDataSourceDisplayed) return <TrayPanelTitle>Data source</TrayPanelTitle>;
-    if (isDefaultPanelView && isAvailableLayoutsDisplayed) return <TrayPanelTitle>Layout</TrayPanelTitle>;
+    if (isDefaultPanelView && isAvailableLayoutsDisplayed) return <TrayPanelTitle>{layoutSectionTitle}</TrayPanelTitle>;
 
     if (contentType === ContentType.DEFAULT || mobileListOpen) return <TrayPanelTitle>Customize</TrayPanelTitle>;
     if (contentType === ContentType.DATE_VARIABLE_PICKER)

--- a/src/components/variables/MobileVariablesTray.tsx
+++ b/src/components/variables/MobileVariablesTray.tsx
@@ -25,7 +25,7 @@ interface VariablesPanelProps {
     selectedLayout: Layout | null;
     layouts: LayoutListItemType[];
     layoutPropertiesState: LayoutPropertiesType;
-    layoutSectionUIOptions: Required<Required<Required<UiOptions>['widgets']>['layoutSection']>;
+    layoutSectionUIOptions: Required<Required<UiOptions>['layoutSection']> & { visible: boolean };
     activePageDetails?: Page;
 
     isTimelineDisplayed?: boolean;
@@ -99,11 +99,14 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
 
     const isLayoutResizable = useMemo(() => selectedLayout?.resizableByUser.enabled ?? false, [selectedLayout]);
 
+    const isLayoutSwitcherVisible = hasAvailableLayouts && layoutSectionUIOptions.layoutSwitcherVisible;
+    const isLayoutResizableVisible = isLayoutResizable;
+
     const isAvailableLayoutsDisplayed =
         layoutsMobileOptionsListOpen ||
-        ((hasAvailableLayouts || isLayoutResizable) &&
-            !variablesMobileOptionsListOpen &&
-            layoutSectionUIOptions.visible);
+        (layoutSectionUIOptions.visible &&
+            (isLayoutSwitcherVisible || isLayoutResizableVisible) &&
+            !variablesMobileOptionsListOpen);
     const isAvailableLayoutSubtitleDisplayed = isDataSourceDisplayed;
 
     const isCustomizeSubtitleDisplayed = isDataSourceDisplayed || isAvailableLayoutsDisplayed;
@@ -183,14 +186,16 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
                                     {isAvailableLayoutSubtitleDisplayed && (
                                         <TrayPanelTitle>{layoutSectionUIOptions.title}</TrayPanelTitle>
                                     )}
-                                    <ListWrapper optionsListOpen={layoutsMobileOptionsListOpen}>
-                                        <AvailableLayouts
-                                            selectedLayout={selectedLayout}
-                                            availableForUserLayouts={availableLayouts}
-                                            mobileDevice
-                                            onMobileOptionListToggle={setLayoutsMobileOptionsListOpen}
-                                        />
-                                    </ListWrapper>
+                                    {isLayoutSwitcherVisible && (
+                                        <ListWrapper optionsListOpen={layoutsMobileOptionsListOpen}>
+                                            <AvailableLayouts
+                                                selectedLayout={selectedLayout}
+                                                availableForUserLayouts={availableLayouts}
+                                                mobileDevice
+                                                onMobileOptionListToggle={setLayoutsMobileOptionsListOpen}
+                                            />
+                                        </ListWrapper>
+                                    )}
                                     {isLayoutResizable && !layoutsMobileOptionsListOpen && (
                                         <LayoutProperties
                                             layout={layoutPropertiesState}

--- a/src/components/variables/MobileVariablesTray.tsx
+++ b/src/components/variables/MobileVariablesTray.tsx
@@ -5,25 +5,27 @@ import { css } from 'styled-components';
 import { useFeatureFlagContext } from '../../contexts/FeatureFlagProvider';
 import { useVariablePanelContext } from '../../contexts/VariablePanelContext';
 import { ContentType } from '../../contexts/VariablePanelContext.types';
+import { UiOptions } from '../../types/types';
 import { APP_WRAPPER_ID } from '../../utils/constants';
 import { getDataTestIdForSUI } from '../../utils/dataIds';
 import DataSourceInput from '../dataSource/DataSourceInput';
 import DataSourceTable from '../dataSource/DataSourceTable';
 import useDataSource from '../dataSource/useDataSource';
 import ImagePanel from '../imagePanel/ImagePanel';
+import AvailableLayouts from '../layout-panels/leftPanel/AvailableLayouts';
+import LayoutProperties from '../LayoutPanel/LayoutProperties';
 import { DataSourceTableWrapper, dataSourceTrayStyles, TrayStyle } from './MobileTray.styles';
 import MobileTrayHeader from './MobileTrayHeader';
 import MobileVariablesList from './MobileVariablesList';
 import useDataSourceInputHandler from './useDataSourceInputHandler';
 import { EditButtonWrapper, ListWrapper, TrayPanelTitle, VariablesContainer } from './VariablesPanel.styles';
-import AvailableLayouts from '../layout-panels/leftPanel/AvailableLayouts';
-import LayoutProperties from '../LayoutPanel/LayoutProperties';
 
 interface VariablesPanelProps {
     variables: Variable[];
     selectedLayout: Layout | null;
     layouts: LayoutListItemType[];
     layoutPropertiesState: LayoutPropertiesType;
+    layoutSectionUIOptions: Required<Required<Required<UiOptions>['widgets']>['layoutSection']>;
     activePageDetails?: Page;
 
     isTimelineDisplayed?: boolean;
@@ -46,6 +48,7 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
         isPagesPanelDisplayed,
         layoutPropertiesState,
         activePageDetails,
+        layoutSectionUIOptions,
     } = props;
     const availableLayouts = useMemo(() => layouts.filter((item) => item.availableForUser), [layouts]);
 
@@ -97,7 +100,10 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
     const isLayoutResizable = useMemo(() => selectedLayout?.resizableByUser.enabled ?? false, [selectedLayout]);
 
     const isAvailableLayoutsDisplayed =
-        layoutsMobileOptionsListOpen || ((hasAvailableLayouts || isLayoutResizable) && !variablesMobileOptionsListOpen);
+        layoutsMobileOptionsListOpen ||
+        ((hasAvailableLayouts || isLayoutResizable) &&
+            !variablesMobileOptionsListOpen &&
+            layoutSectionUIOptions.visible);
     const isAvailableLayoutSubtitleDisplayed = isDataSourceDisplayed;
 
     const isCustomizeSubtitleDisplayed = isDataSourceDisplayed || isAvailableLayoutsDisplayed;
@@ -137,6 +143,7 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
                 close={closeTray}
                 title={
                     <MobileTrayHeader
+                        layoutSectionTitle={layoutSectionUIOptions.title}
                         isDefaultPanelView={isDefaultPanelView}
                         isDataSourceDisplayed={isDataSourceDisplayed || false}
                         isAvailableLayoutsDisplayed={isAvailableLayoutsDisplayed}
@@ -173,7 +180,9 @@ function MobileVariablesPanel(props: VariablesPanelProps) {
                             ) : null}
                             {isAvailableLayoutsDisplayed && !isDateVariablePanelOpen && (
                                 <>
-                                    {isAvailableLayoutSubtitleDisplayed && <TrayPanelTitle>Layout</TrayPanelTitle>}
+                                    {isAvailableLayoutSubtitleDisplayed && (
+                                        <TrayPanelTitle>{layoutSectionUIOptions.title}</TrayPanelTitle>
+                                    )}
                                     <ListWrapper optionsListOpen={layoutsMobileOptionsListOpen}>
                                         <AvailableLayouts
                                             selectedLayout={selectedLayout}

--- a/src/contexts/UiConfigContext.tsx
+++ b/src/contexts/UiConfigContext.tsx
@@ -5,8 +5,8 @@ import { IUiConfigContext } from './UiConfigContext.types';
 export const UiConfigContextDefaultValues: IUiConfigContext = {
     projectConfig: {} as ProjectConfig,
     uiOptions: defaultUiOptions,
-    isDownloadBtnVisible: false,
-    isBackBtnVisible: defaultUiOptions.widgets.downloadButton?.visible || false,
+    isDownloadBtnVisible: defaultUiOptions.widgets.downloadButton.visible,
+    isBackBtnVisible: defaultUiOptions.widgets.backButton.visible,
     graFxStudioEnvironmentApiBaseUrl: '',
     onVariableFocus: () => null,
     onVariableBlur: () => null,

--- a/src/tests/LayoutSectionUIOptions.test.tsx
+++ b/src/tests/LayoutSectionUIOptions.test.tsx
@@ -1,0 +1,516 @@
+// studio-ui/src/tests/LayoutSectionUIOptions.test.tsx
+import { UiThemeProvider, useMobileSize } from '@chili-publish/grafx-shared-components';
+import { ConfigType, LayoutListItemType } from '@chili-publish/studio-sdk';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import AppProvider from '../contexts/AppProvider';
+import { SubscriberContextProvider } from '../contexts/Subscriber';
+import MainContent from '../MainContent';
+import { ProjectConfig } from '../types/types';
+import { getDataTestIdForSUI } from '../utils/dataIds';
+import { Subscriber } from '../utils/subscriber';
+
+// Mock the useMobileSize hook
+jest.mock('@chili-publish/grafx-shared-components', () => ({
+    __esModule: true,
+    ...jest.requireActual('@chili-publish/grafx-shared-components'),
+    useMobileSize: jest.fn(),
+}));
+
+jest.mock('@chili-publish/studio-sdk', () => {
+    const originalModule = jest.requireActual('@chili-publish/studio-sdk');
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        /* eslint-disable */
+
+        default: function (config: ConfigType) {
+            const sdk = new originalModule.default(config);
+            /* eslint-enable */
+            return {
+                ...sdk,
+                loadEditor: jest.fn(),
+                document: {
+                    load: jest.fn().mockResolvedValue({ success: true }),
+                    getCurrentState: jest.fn().mockResolvedValue({ data: '{}' }),
+                },
+                configuration: {
+                    setValue: jest.fn(),
+                },
+                tool: {
+                    setHand: jest.fn(),
+                },
+                next: {
+                    connector: {
+                        getAllByType: jest.fn().mockResolvedValue({ success: true, parsedData: [] }),
+                        getById: jest.fn().mockResolvedValue({ success: true }),
+                    },
+                },
+                dataSource: {
+                    getDataSource: jest.fn().mockResolvedValue({ success: true }),
+                },
+                layout: {
+                    getSelected: jest.fn().mockResolvedValue({
+                        parsedData: {
+                            intent: { value: null },
+                            id: 'Layout-1',
+                            name: 'Layout 1',
+                        },
+                    }),
+                },
+                canvas: {
+                    zoomToPage: jest.fn(),
+                },
+            };
+        },
+    };
+});
+
+const mockProjectConfig = {
+    projectId: '123',
+    projectName: 'Test Project',
+    sandboxMode: false,
+    onProjectLoaded: jest.fn(),
+    onProjectDocumentRequested: jest.fn().mockResolvedValue('{}'),
+    onProjectInfoRequested: jest.fn().mockResolvedValue({}),
+    onProjectSave: jest.fn(),
+    onAuthenticationExpired: jest.fn(),
+    outputSettings: {},
+} as unknown as ProjectConfig;
+
+describe('Layout Section UI Options', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    afterAll(() => {
+        jest.resetAllMocks();
+    });
+    const setMobileView = (isMobile: boolean) => {
+        (useMobileSize as jest.Mock).mockReturnValue(isMobile);
+    };
+
+    describe('Desktop View', () => {
+        beforeEach(() => {
+            setMobileView(false);
+        });
+
+        it('should not render layout when widget is false', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: false,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            // Wait for async operations to complete
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+            expect(screen.queryByText('Layout')).not.toBeInTheDocument();
+        });
+
+        it('should not render layout in multiLayout view', async () => {
+            const { rerender } = render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+            rerender(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                    onSetMultiLayout: (setter) => setter(true),
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            expect(screen.queryByText('Layout')).not.toBeInTheDocument();
+        });
+
+        it('should render layout with default title when widget is true', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            expect(screen.getByText('Layout')).toBeInTheDocument();
+        });
+
+        it('should render layout with custom title', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                                title: 'Custom Layout Title',
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                            ,
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+            expect(screen.getByText('Custom Layout Title')).toBeInTheDocument();
+        });
+    });
+
+    describe('Mobile View', () => {
+        beforeEach(() => {
+            setMobileView(true);
+        });
+
+        it('should not render layout when widget is false', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: false,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+
+            const openTrayBtn = screen.getByTestId(getDataTestIdForSUI('mobile-variables'));
+
+            await userEvent.click(openTrayBtn);
+
+            expect(screen.getByTestId('test-gsc-tray-header')).toHaveTextContent('Customize');
+            expect(screen.queryByText('Layout')).not.toBeInTheDocument();
+        });
+
+        it('should not render layout in multiLayout view', async () => {
+            const { rerender } = render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+
+            rerender(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                    onSetMultiLayout: (setter) => setter(true),
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            const openTrayBtn = screen.getByTestId(getDataTestIdForSUI('mobile-variables'));
+
+            await userEvent.click(openTrayBtn);
+
+            expect(screen.getByTestId('test-gsc-tray-header')).toHaveTextContent('Customize');
+            expect(screen.queryByText('Layout')).not.toBeInTheDocument();
+        });
+
+        it('should render layout with default title when widget is true', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+
+            const openTrayBtn = screen.getByTestId(getDataTestIdForSUI('mobile-variables'));
+
+            await userEvent.click(openTrayBtn);
+
+            expect(screen.getByTestId('test-gsc-tray-header')).toHaveTextContent('Layout');
+            expect(screen.queryByText('Customize')).toBeInTheDocument();
+        });
+
+        it('should render layout with custom title', async () => {
+            render(
+                <AppProvider isDocumentLoaded>
+                    <SubscriberContextProvider subscriber={new Subscriber()}>
+                        <UiThemeProvider theme="platform">
+                            <MainContent
+                                projectConfig={{
+                                    ...mockProjectConfig,
+                                    uiOptions: {
+                                        widgets: {
+                                            layoutSection: {
+                                                visible: true,
+                                                title: 'Custom Layout Title',
+                                            },
+                                        },
+                                    },
+                                }}
+                                updateToken={jest.fn()}
+                            />
+                        </UiThemeProvider>
+                    </SubscriberContextProvider>
+                </AppProvider>,
+            );
+
+            await act(() => {
+                window.StudioUISDK.config.events.onLayoutsChanged.trigger([
+                    {
+                        id: 'Layout-1',
+                        name: 'Layout 1',
+                        availableForUser: true,
+                    },
+                    {
+                        id: 'Layout-2',
+                        name: 'Layout 2',
+                        availableForUser: true,
+                    },
+                ] as LayoutListItemType[]);
+            });
+
+            await screen.findByTestId(getDataTestIdForSUI('canvas'));
+
+            const openTrayBtn = screen.getByTestId(getDataTestIdForSUI('mobile-variables'));
+
+            await userEvent.click(openTrayBtn);
+
+            expect(screen.getByTestId('test-gsc-tray-header')).toHaveTextContent('Custom Layout Title');
+            expect(screen.queryByText('Customize')).toBeInTheDocument();
+        });
+    });
+});

--- a/src/tests/LayoutSectionUIOptions.test.tsx
+++ b/src/tests/LayoutSectionUIOptions.test.tsx
@@ -96,7 +96,7 @@ describe('Layout Section UI Options', () => {
             setMobileView(false);
         });
 
-        it('should not render layout when widget is false', async () => {
+        it('should not render layout section when "layoutSwitcherVisible" is false', async () => {
             render(
                 <AppProvider isDocumentLoaded>
                     <SubscriberContextProvider subscriber={new Subscriber()}>
@@ -105,10 +105,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: false,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: false,
                                         },
                                     },
                                 }}
@@ -148,10 +146,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                 }}
@@ -186,10 +182,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                     onSetMultiLayout: (setter) => setter(true),
@@ -213,10 +207,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                 }}
@@ -256,11 +248,9 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                                title: 'Custom Layout Title',
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
+                                            title: 'Custom Layout Title',
                                         },
                                     },
                                 }}
@@ -306,10 +296,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: false,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: false,
                                         },
                                     },
                                 }}
@@ -354,10 +342,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                 }}
@@ -393,10 +379,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                     onSetMultiLayout: (setter) => setter(true),
@@ -425,10 +409,8 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
                                         },
                                     },
                                 }}
@@ -473,11 +455,9 @@ describe('Layout Section UI Options', () => {
                                 projectConfig={{
                                     ...mockProjectConfig,
                                     uiOptions: {
-                                        widgets: {
-                                            layoutSection: {
-                                                visible: true,
-                                                title: 'Custom Layout Title',
-                                            },
+                                        layoutSection: {
+                                            layoutSwitcherVisible: true,
+                                            title: 'Custom Layout Title',
                                         },
                                     },
                                 }}

--- a/src/tests/LeftPanel.test.tsx
+++ b/src/tests/LeftPanel.test.tsx
@@ -1,12 +1,12 @@
 import { UiThemeProvider, getDataTestId } from '@chili-publish/grafx-shared-components';
 import EditorSDK, { LayoutPropertiesType } from '@chili-publish/studio-sdk';
+import { mockAssets } from '@mocks/mockAssets';
+import { mockConnectors } from '@mocks/mockConnectors';
+import { mockLayout, mockLayouts } from '@mocks/mockLayout';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock } from 'jest-mock-extended';
 import { act } from 'react-dom/test-utils';
-import { mockLayout, mockLayouts } from '@mocks/mockLayout';
-import { mockAssets } from '@mocks/mockAssets';
-import { mockConnectors } from '@mocks/mockConnectors';
 import LeftPanel from '../components/layout-panels/leftPanel/LeftPanel';
 import AppProvider from '../contexts/AppProvider';
 import { VariablePanelContextProvider } from '../contexts/VariablePanelContext';
@@ -125,6 +125,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>
@@ -158,6 +162,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>
@@ -191,6 +199,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>
@@ -221,6 +233,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>
@@ -266,6 +282,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>
@@ -298,6 +318,10 @@ describe('Image Panel', () => {
                             selectedLayout={mockLayout}
                             layouts={mockLayouts}
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                            layoutSectionUIOptions={{
+                                visible: false,
+                                title: 'Layout',
+                            }}
                         />
                     </VariablePanelContextProvider>
                 </UiThemeProvider>

--- a/src/tests/LeftPanel.test.tsx
+++ b/src/tests/LeftPanel.test.tsx
@@ -127,6 +127,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />
@@ -164,6 +165,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />
@@ -201,6 +203,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />
@@ -235,6 +238,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />
@@ -284,6 +288,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />
@@ -320,6 +325,7 @@ describe('Image Panel', () => {
                             layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                             layoutSectionUIOptions={{
                                 visible: false,
+                                layoutSwitcherVisible: false,
                                 title: 'Layout',
                             }}
                         />

--- a/src/tests/LeftPanelLayout.test.tsx
+++ b/src/tests/LeftPanelLayout.test.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { UiThemeProvider } from '@chili-publish/grafx-shared-components';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import EditorSDK, { LayoutPropertiesType } from '@chili-publish/studio-sdk';
 import { mockLayout, mockLayouts } from '@mocks/mockLayout';
-import selectEvent from 'react-select-event';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock } from 'jest-mock-extended';
-import EditorSDK, { LayoutPropertiesType } from '@chili-publish/studio-sdk';
+import selectEvent from 'react-select-event';
+import { mockConnectors } from '../../__mocks__/mockConnectors';
 import LeftPanel from '../components/layout-panels/leftPanel/LeftPanel';
 import { VariablePanelContextProvider } from '../contexts/VariablePanelContext';
-import { mockConnectors } from '../../__mocks__/mockConnectors';
+import { getDataTestIdForSUI } from '../utils/dataIds';
 import { variables } from './mocks/mockVariables';
 import { APP_WRAPPER } from './shared.util/app';
-import { getDataTestIdForSUI } from '../utils/dataIds';
 
 afterEach(() => {
     jest.clearAllMocks();
@@ -35,6 +35,10 @@ describe('Layout selection', () => {
                         selectedLayout={mockLayout}
                         layouts={singleAvailableLayout}
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                        layoutSectionUIOptions={{
+                            visible: true,
+                            title: 'Layout',
+                        }}
                     />
                 </VariablePanelContextProvider>
             </UiThemeProvider>,
@@ -62,6 +66,10 @@ describe('Layout selection', () => {
                         selectedLayout={nonResizableLayout}
                         layouts={singleAvailableLayout}
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                        layoutSectionUIOptions={{
+                            visible: true,
+                            title: 'Layout',
+                        }}
                     />
                 </VariablePanelContextProvider>
             </UiThemeProvider>,
@@ -82,6 +90,10 @@ describe('Layout selection', () => {
                         selectedLayout={mockLayout}
                         layouts={mockLayouts}
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                        layoutSectionUIOptions={{
+                            visible: true,
+                            title: 'Layout',
+                        }}
                     />
                 </VariablePanelContextProvider>
             </UiThemeProvider>,

--- a/src/tests/LeftPanelLayout.test.tsx
+++ b/src/tests/LeftPanelLayout.test.tsx
@@ -37,6 +37,7 @@ describe('Layout selection', () => {
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                         layoutSectionUIOptions={{
                             visible: true,
+                            layoutSwitcherVisible: true,
                             title: 'Layout',
                         }}
                     />
@@ -68,6 +69,7 @@ describe('Layout selection', () => {
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                         layoutSectionUIOptions={{
                             visible: true,
+                            layoutSwitcherVisible: true,
                             title: 'Layout',
                         }}
                     />
@@ -92,6 +94,7 @@ describe('Layout selection', () => {
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                         layoutSectionUIOptions={{
                             visible: true,
+                            layoutSwitcherVisible: true,
                             title: 'Layout',
                         }}
                     />

--- a/src/tests/MobileVariableTrayLayout.test.tsx
+++ b/src/tests/MobileVariableTrayLayout.test.tsx
@@ -65,6 +65,7 @@ describe('MobileVariableTrayLayout', () => {
                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                     layoutSectionUIOptions={{
                         visible: true,
+                        layoutSwitcherVisible: true,
                         title: 'Layout',
                     }}
                 />
@@ -75,6 +76,8 @@ describe('MobileVariableTrayLayout', () => {
         const openTrayBtn = screen.getByRole('button');
 
         await userEvent.click(openTrayBtn);
+
+        await waitFor(() => expect(screen.getByTestId('test-gsc-tray-header')).toBeInTheDocument());
 
         expect(screen.getByTestId('test-gsc-tray-header')).toHaveTextContent('Layout');
         expect(screen.getByText('Customize')).toBeInTheDocument();
@@ -91,6 +94,7 @@ describe('MobileVariableTrayLayout', () => {
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                         layoutSectionUIOptions={{
                             visible: true,
+                            layoutSwitcherVisible: true,
                             title: 'Layout',
                         }}
                     />
@@ -118,6 +122,7 @@ describe('MobileVariableTrayLayout', () => {
                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                     layoutSectionUIOptions={{
                         visible: true,
+                        layoutSwitcherVisible: true,
                         title: 'Layout',
                     }}
                 />

--- a/src/tests/MobileVariableTrayLayout.test.tsx
+++ b/src/tests/MobileVariableTrayLayout.test.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { UiThemeProvider } from '@chili-publish/grafx-shared-components';
-import { act, render, screen, waitFor } from '@testing-library/react';
-import { mockLayout, mockLayouts } from '@mocks/mockLayout';
-import { mock } from 'jest-mock-extended';
 import EditorSDK, { ConnectorRegistrationSource, LayoutPropertiesType } from '@chili-publish/studio-sdk';
+import { mockLayout, mockLayouts } from '@mocks/mockLayout';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { mock } from 'jest-mock-extended';
 import MobileVariablesPanel from '../components/variables/MobileVariablesTray';
-import { APP_WRAPPER } from './shared.util/app';
-import { variables } from './mocks/mockVariables';
 import FeatureFlagProvider from '../contexts/FeatureFlagProvider';
 import { getDataIdForSUI } from '../utils/dataIds';
+import { variables } from './mocks/mockVariables';
+import { APP_WRAPPER } from './shared.util/app';
 
 afterEach(() => {
     jest.clearAllMocks();
@@ -63,6 +63,10 @@ describe('MobileVariableTrayLayout', () => {
                     selectedLayout={mockLayout}
                     layouts={mockLayouts}
                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                    layoutSectionUIOptions={{
+                        visible: true,
+                        title: 'Layout',
+                    }}
                 />
             </UiThemeProvider>,
             { container: document.body.appendChild(APP_WRAPPER) },
@@ -85,6 +89,10 @@ describe('MobileVariableTrayLayout', () => {
                         selectedLayout={mockLayout}
                         layouts={mockLayouts}
                         layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                        layoutSectionUIOptions={{
+                            visible: true,
+                            title: 'Layout',
+                        }}
                     />
                 </FeatureFlagProvider>
             </UiThemeProvider>,
@@ -108,6 +116,10 @@ describe('MobileVariableTrayLayout', () => {
                     selectedLayout={mockLayout}
                     layouts={mockLayouts}
                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                    layoutSectionUIOptions={{
+                        visible: true,
+                        title: 'Layout',
+                    }}
                 />
             </UiThemeProvider>,
             { container: document.body.appendChild(APP_WRAPPER) },

--- a/src/tests/components/dataSource/MobileDataSourceTray.test.tsx
+++ b/src/tests/components/dataSource/MobileDataSourceTray.test.tsx
@@ -1,9 +1,9 @@
 import { UiThemeProvider } from '@chili-publish/grafx-shared-components';
+import { LayoutPropertiesType } from '@chili-publish/studio-sdk';
 import { ConnectorInstance } from '@chili-publish/studio-sdk/lib/src/next';
+import { mockLayout, mockLayouts } from '@mocks/mockLayout';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockLayout, mockLayouts } from '@mocks/mockLayout';
-import { LayoutPropertiesType } from '@chili-publish/studio-sdk';
 import MobileVariablesPanel from '../../../components/variables/MobileVariablesTray';
 import AppProvider from '../../../contexts/AppProvider';
 import FeatureFlagProvider from '../../../contexts/FeatureFlagProvider';
@@ -68,6 +68,10 @@ describe('MobileDataSource test', () => {
                                 selectedLayout={mockLayout}
                                 layouts={mockLayouts}
                                 layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                                layoutSectionUIOptions={{
+                                    visible: false,
+                                    title: 'Layout',
+                                }}
                             />
                         </FeatureFlagProvider>
                     </UiThemeProvider>
@@ -102,6 +106,10 @@ describe('MobileDataSource test', () => {
                                     selectedLayout={mockLayout}
                                     layouts={mockLayouts}
                                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
+                                    layoutSectionUIOptions={{
+                                        visible: false,
+                                        title: 'Layout',
+                                    }}
                                 />
                             </FeatureFlagProvider>
                         </VariablePanelContextProvider>

--- a/src/tests/components/dataSource/MobileDataSourceTray.test.tsx
+++ b/src/tests/components/dataSource/MobileDataSourceTray.test.tsx
@@ -70,6 +70,7 @@ describe('MobileDataSource test', () => {
                                 layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                                 layoutSectionUIOptions={{
                                     visible: false,
+                                    layoutSwitcherVisible: false,
                                     title: 'Layout',
                                 }}
                             />
@@ -108,6 +109,7 @@ describe('MobileDataSource test', () => {
                                     layoutPropertiesState={mockLayout as unknown as LayoutPropertiesType}
                                     layoutSectionUIOptions={{
                                         visible: false,
+                                        layoutSwitcherVisible: false,
                                         title: 'Layout',
                                     }}
                                 />

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -81,7 +81,7 @@ export type DownloadLinkResult = {
 
 export interface UiOptions {
     theme?: UiThemeConfig;
-    widgets: {
+    widgets?: {
         downloadButton?: {
             visible?: boolean;
         };
@@ -94,6 +94,10 @@ export interface UiOptions {
         };
         bottomBar?: {
             visible?: boolean;
+        };
+        layoutSection?: {
+            visible?: boolean;
+            title?: string;
         };
     };
 }
@@ -146,13 +150,17 @@ export interface IOutputSetting {
     watermark: boolean;
 }
 
-export const defaultUiOptions: UiOptions = {
+export const defaultUiOptions = {
     widgets: {
         downloadButton: {
             visible: true,
         },
         backButton: {
             visible: false,
+        },
+        layoutSection: {
+            visible: true,
+            title: 'Layout',
         },
     },
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -95,10 +95,13 @@ export interface UiOptions {
         bottomBar?: {
             visible?: boolean;
         };
-        layoutSection?: {
-            visible?: boolean;
-            title?: string;
-        };
+    };
+    /**
+     * Experimental. Don't use in production. Will be changed soon.
+     */
+    layoutSection?: {
+        layoutSwitcherVisible?: boolean;
+        title?: string;
     };
 }
 
@@ -158,10 +161,10 @@ export const defaultUiOptions = {
         backButton: {
             visible: false,
         },
-        layoutSection: {
-            visible: true,
-            title: 'Layout',
-        },
+    },
+    layoutSection: {
+        layoutSwitcherVisible: true,
+        title: 'Layout',
     },
 };
 


### PR DESCRIPTION
This PR adds:
- Certain option to show/hide the layout switcher component
- Certain option to rename the layout section title
- Always hide layout section for MultiLayoutView

## Related tickets

-   [WRS-2313](https://chilipublishintranet.atlassian.net/browse/WRS-2313)

## Screenshots


[WRS-2313]: https://chilipublishintranet.atlassian.net/browse/WRS-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ