### PR TITLE
[Fix] [WRS-2412] Fix output settings format being undefined

### DIFF
--- a/src/components/navbar/downloadPanel/DownloadPanel.tsx
+++ b/src/components/navbar/downloadPanel/DownloadPanel.tsx
@@ -72,7 +72,7 @@ function DownloadPanel(props: DownloadPanelProps) {
         updateDownloadState,
         handleOutputFormatChange,
         selectedOutputSettingsId,
-    } = useDownload(hideDownloadPanel);
+    } = useDownload({ hideDownloadPanel, isSandBoxMode });
 
     const outputSettingsOptions = useMemo(() => {
         if (!isSandBoxMode) return [];

--- a/src/components/navbar/downloadPanel/useDownload.tsx
+++ b/src/components/navbar/downloadPanel/useDownload.tsx
@@ -6,8 +6,15 @@ import { UserInterfaceOutputSettings } from '../../../types/types';
 import { outputTypesIcons } from './DownloadPanel.types';
 import { useOutputSettingsContext } from '../OutputSettingsContext';
 
-const useDownload = (hideDownloadPanel: () => void) => {
-    const { outputSettings, userInterfaceOutputSettings } = useOutputSettingsContext();
+const useDownload = ({
+    hideDownloadPanel,
+    isSandBoxMode,
+}: {
+    hideDownloadPanel: () => void;
+    isSandBoxMode?: boolean;
+}) => {
+    const { outputSettings, userInterfaceOutputSettings, outputSettingsFullList } = useOutputSettingsContext();
+
     const initialDownloadState: Record<DownloadFormats, boolean> = {
         [DownloadFormats.JPG]: false,
         [DownloadFormats.PNG]: false,
@@ -88,9 +95,17 @@ const useDownload = (hideDownloadPanel: () => void) => {
         });
     }, [userInterfaceOutputSettings]);
 
-    const getFormatFromId = useCallback((id: string, availableOutputs: UserInterfaceOutputSettings[]) => {
-        return availableOutputs.find((output) => output.id === id)?.type.toLocaleLowerCase() as DownloadFormats;
-    }, []);
+    const getFormatFromId = useCallback(
+        (id: string, availableOutputs: UserInterfaceOutputSettings[]) => {
+            if (isSandBoxMode && outputSettingsFullList) {
+                return outputSettingsFullList
+                    .find((output) => output.id === id)
+                    ?.type.toLocaleLowerCase() as DownloadFormats;
+            }
+            return availableOutputs.find((output) => output.id === id)?.type.toLocaleLowerCase() as DownloadFormats;
+        },
+        [isSandBoxMode, outputSettingsFullList],
+    );
 
     useEffect(() => {
         if (userInterfaceOutputSettings && userInterfaceOutputSettings.length > 0) {

--- a/src/components/navbar/navbarItems/useNavbarDownloadBtn.tsx
+++ b/src/components/navbar/navbarItems/useNavbarDownloadBtn.tsx
@@ -7,7 +7,7 @@ import { useOutputSettingsContext } from '../OutputSettingsContext';
 
 const useNavbarDownloadBtn = (onDownloadPanelOpen: () => void, isSandBoxMode?: boolean) => {
     const { isDownloadBtnVisible } = useUiConfigContext();
-    const { userInterfaceOutputSettings } = useOutputSettingsContext();
+    const { userInterfaceOutputSettings, outputSettingsFullList } = useOutputSettingsContext();
     const isMobile = useMobileSize();
 
     const label = isSandBoxMode ? 'Export' : 'Download';
@@ -35,12 +35,24 @@ const useNavbarDownloadBtn = (onDownloadPanelOpen: () => void, isSandBoxMode?: b
                               icon={AvailableIcons.faArrowDownToLine}
                               variant={ButtonVariant.primary}
                               handleOnClick={onDownloadPanelOpen}
-                              disabled={userInterfaceOutputSettings?.length === 0}
+                              disabled={
+                                  isSandBoxMode
+                                      ? outputSettingsFullList?.length === 0
+                                      : userInterfaceOutputSettings?.length === 0
+                              }
                           />
                       ),
                   }
                 : null,
-        [isMobile, isVisible, label, onDownloadPanelOpen, userInterfaceOutputSettings?.length],
+        [
+            isMobile,
+            isSandBoxMode,
+            isVisible,
+            label,
+            onDownloadPanelOpen,
+            outputSettingsFullList?.length,
+            userInterfaceOutputSettings?.length,
+        ],
     );
 
     return {

--- a/src/tests/navbar/useDownload.test.tsx
+++ b/src/tests/navbar/useDownload.test.tsx
@@ -9,7 +9,7 @@ describe('useDownload', () => {
         jest.spyOn(UiConfigContext, 'useUiConfigContext').mockImplementation(() => {
             return UiConfigContext.UiConfigContextDefaultValues;
         });
-        const { result } = renderHook(() => useDownload(() => null));
+        const { result } = renderHook(() => useDownload({ hideDownloadPanel: () => null }));
         expect(result.current.downloadOptions.length).toBe(5);
     });
 
@@ -20,7 +20,7 @@ describe('useDownload', () => {
                 outputSettings: { mp4: false, gif: false, jpg: false, pdf: false },
             };
         });
-        const { result } = renderHook(() => useDownload(() => null));
+        const { result } = renderHook(() => useDownload({ hideDownloadPanel: () => null }));
         expect(result.current.downloadOptions.length).toBe(1);
         expect(result.current.downloadOptions[0].value).toBe(DownloadFormats.PNG);
     });
@@ -32,7 +32,7 @@ describe('useDownload', () => {
                 outputSettings: { mp4: true, gif: true },
             };
         });
-        const { result } = renderHook(() => useDownload(() => null));
+        const { result } = renderHook(() => useDownload({ hideDownloadPanel: () => null }));
         expect(result.current.downloadOptions.length).toBe(2);
         expect(result.current.downloadOptions[0].value).toBe(DownloadFormats.MP4);
     });
@@ -44,7 +44,7 @@ describe('useDownload', () => {
                 outputSettings: { mp4: true, gif: false },
             };
         });
-        const { result } = renderHook(() => useDownload(() => null));
+        const { result } = renderHook(() => useDownload({ hideDownloadPanel: () => null }));
         expect(result.current.downloadOptions.length).toBe(1);
         expect(result.current.downloadOptions[0].value).toBe(DownloadFormats.MP4);
     });
@@ -73,7 +73,7 @@ describe('useDownload', () => {
                 ],
             };
         });
-        const { result } = renderHook(() => useDownload(() => null));
+        const { result } = renderHook(() => useDownload({ hideDownloadPanel: () => null }));
         expect(result.current.userInterfaceDownloadOptions?.length).toBe(2);
     });
 });


### PR DESCRIPTION
This PR Fixes output settings format being undefined, and adjust `disabled` status for `Export` button on run mode

## Related tickets

-   [WRS-2412](https://chilipublishintranet.atlassian.net/browse/WRS-2412)

## Screenshots


[WRS-2412]: https://chilipublishintranet.atlassian.net/browse/WRS-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ