### PR TITLE
[Feat] Fetch engine commit sha from backend for main or pr

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PREVIEW_ERROR_URL=https://cdnepgrafxstudioprd.azureedge.net/shared/assets/preview-fallback-padded.svg

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.env
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.2",
+        "@types/js-cookie": "^3.0.6",
         "@types/react": "^18.2.8",
         "@types/react-dom": "^18.2.4",
         "@types/redux-logger": "^3.0.13",
@@ -84,14 +85,14 @@
         "jest-environment-jsdom": "^29.5.0",
         "jest-junit": "^16.0.0",
         "jest-mock-extended": "^3.0.4",
+        "js-cookie": "^3.0.5",
         "prettier": "^2.8.8",
         "pretty-quick": "^3.1.3",
         "react-select-event": "^5.5.1",
         "resize-observer-polyfill": "^1.5.1",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3",
-        "vite": "^4.3.9",
-        "vite-plugin-environment": "^1.1.3"
+        "vite": "^4.3.9"
     },
     "husky": {
         "hooks": {

--- a/src/_dev-execution/bootstrap.ts
+++ b/src/_dev-execution/bootstrap.ts
@@ -29,12 +29,11 @@ import { EngineVersionManager } from './version-manager';
     const engineVersionManager = new EngineVersionManager(authToken);
 
     const engineVersion = urlParams.get('engine') ?? 'main';
-    const engineCommitSha = urlParams.get('engineCommitSha') ?? (await engineVersionManager.getLatestCommitSha());
+    const engineCommitSha =
+        urlParams.get('engineCommitSha') ?? (await engineVersionManager.getLatestCommitSha(engineVersion));
 
     // The following will take released versions in consideration
     const engineRegex = /^\d+\.\d+\.\d+$/;
-    const engineSource =
-        engineRegex.test(engineVersion) || !engineCommitSha ? engineVersion : `${engineVersion}-${engineCommitSha}`;
 
     const envName = import.meta.env.VITE_ENVIRONMENT_NAME;
     const projectId = import.meta.env.VITE_PROJECT_ID;
@@ -59,6 +58,8 @@ import { EngineVersionManager } from './version-manager';
 
         return;
     }
+
+    const engineSource = engineRegex.test(engineVersion) ? engineVersion : `${engineVersion}-${engineCommitSha}`;
 
     StudioUI.studioUILoaderConfig({
         selector: 'sui-root',

--- a/src/_dev-execution/bootstrap.ts
+++ b/src/_dev-execution/bootstrap.ts
@@ -3,6 +3,7 @@
 
 import StudioUI from '../main';
 import { TokenManager } from './token-manager';
+import { EngineVersionManager } from './version-manager';
 
 (async () => {
     const tokenManager = new TokenManager();
@@ -10,7 +11,7 @@ import { TokenManager } from './token-manager';
     let urlParams = new URLSearchParams(window.location.search);
 
     // state after redirection
-    if (urlParams.has('code') && urlParams.has('code')) {
+    if (urlParams.has('code')) {
         const res = await tokenManager.redirectCallback();
         if (res.appState) {
             window.history.replaceState(null, '', res.appState.returnTo);
@@ -18,22 +19,22 @@ import { TokenManager } from './token-manager';
         }
     }
 
+    let authToken = '';
+    if (import.meta.env.VITE_TOKEN) {
+        authToken = import.meta.env.VITE_TOKEN;
+    } else {
+        authToken = await tokenManager.getAccessToken();
+    }
+
+    const engineVersionManager = new EngineVersionManager(authToken);
+
     const engineVersion = urlParams.get('engine') ?? 'main';
-    // When devloping locally make sure you change the engine commit hash, you can get it from opening studio in platform
-    // or from engine github repo
-    const engineCommitSha = urlParams.get('engineCommitSha') ?? import.meta.env.VITE_ENGINE_COMMIT_SHA ?? '';
+    const engineCommitSha = urlParams.get('engineCommitSha') ?? (await engineVersionManager.getLatestCommitSha());
+
     // The following will take released versions in consideration
     const engineRegex = /^\d+\.\d+\.\d+$/;
     const engineSource =
         engineRegex.test(engineVersion) || !engineCommitSha ? engineVersion : `${engineVersion}-${engineCommitSha}`;
-
-    // Set the values to the url
-    if (!urlParams.get('engine')) {
-        window.history.replaceState(null, '', `${window.location.href}?engine=${engineVersion}`);
-    }
-    if (!urlParams.get('engineCommitSha') && !engineRegex.test(engineVersion)) {
-        window.history.replaceState(null, '', `${window.location.href}&engineCommitSha=${engineCommitSha}`);
-    }
 
     const envName = import.meta.env.VITE_ENVIRONMENT_NAME;
     const projectId = import.meta.env.VITE_PROJECT_ID;
@@ -59,12 +60,6 @@ import { TokenManager } from './token-manager';
         return;
     }
 
-    let authToken = '';
-    if (import.meta.env.VITE_TOKEN) {
-        authToken = import.meta.env.VITE_TOKEN;
-    } else {
-        authToken = await tokenManager.getAccessToken();
-    }
     StudioUI.studioUILoaderConfig({
         selector: 'sui-root',
         projectId,

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -1,8 +1,8 @@
 import Cookies from 'js-cookie';
 
 interface EngineVerion {
-    name: string;
-    successCommitHash: string;
+    path: string;
+    commitHash?: string;
 }
 
 export class EngineVersionManager {
@@ -16,28 +16,29 @@ export class EngineVersionManager {
         this.authToken = authToken;
     }
 
-    async getLatestCommitSha(): Promise<string | null> {
-        const cachedData = Cookies.get('engineCommitSha');
+    async getLatestCommitSha(branchPath: string): Promise<string | null> {
+        const cachedData = Cookies.get(`${branchPath}-engineCommitSha`);
 
         if (cachedData) {
             return cachedData;
         }
 
-        const commitSha = await this.fetchLatestCommitSha();
+        const commitSha = await this.fetchLatestCommitSha(branchPath);
         if (commitSha) {
-            Cookies.set('engineCommitSha', commitSha, { expires: this.CACHE_TTL });
+            Cookies.set(`${branchPath}-engineCommitSha`, commitSha, { expires: this.CACHE_TTL });
         }
 
         return commitSha;
     }
 
-    private async fetchLatestCommitSha(): Promise<string | null> {
+    private async fetchLatestCommitSha(branchPath: string): Promise<string | null> {
+        const selected = branchPath === 'main' ? 'latest' : branchPath;
         const data: Array<EngineVerion> = await fetch(`${this.baseUrl}/studio-engine`, {
             headers: {
                 Authorization: `Bearer ${this.authToken}`,
                 'Content-Type': 'application/json',
             },
         }).then((res) => res.json());
-        return data.find((v) => v.name === 'latest')?.successCommitHash ?? null;
+        return data.find((v) => v.path === selected)?.commitHash ?? null;
     }
 }

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -8,7 +8,7 @@ interface EngineVerion {
 export class EngineVersionManager {
     private readonly baseUrl = 'https://dev.devapi.chiligrafx-dev.com/version-management';
 
-    private readonly CACHE_TTL = 120; // 2 minutes in seconds
+    private readonly CACHE_TTL = 60 * 60; // 1h (in seconds)
 
     private authToken: string;
 

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -31,11 +31,6 @@ export class EngineVersionManager {
         return commitSha;
     }
 
-    // Method to update the auth token if it changes
-    updateAuthToken(newToken: string): void {
-        this.authToken = newToken;
-    }
-
     private async fetchLatestCommitSha(): Promise<string | null> {
         const data: Array<EngineVerion> = await fetch(`${this.baseUrl}/studio-engine`, {
             headers: {

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -1,0 +1,46 @@
+import Cookies from 'js-cookie';
+
+interface EngineVerion {
+    name: string;
+    successCommitHash: string;
+}
+
+export class EngineVersionManager {
+    private readonly baseUrl = 'https://dev.devapi.chiligrafx-dev.com/version-management';
+    private readonly CACHE_TTL = 120; // 2 minutes in seconds
+    private authToken: string;
+
+    constructor(authToken: string) {
+        this.authToken = authToken;
+    }
+
+    async getLatestCommitSha(): Promise<string | null> {
+        const cachedData = Cookies.get('engineCommitSha');
+
+        if (cachedData) {
+            return cachedData;
+        }
+
+        const commitSha = await this.fetchLatestCommitSha();
+        if (commitSha) {
+            Cookies.set('engineCommitSha', commitSha, { expires: this.CACHE_TTL });
+        }
+
+        return commitSha;
+    }
+
+    // Method to update the auth token if it changes
+    updateAuthToken(newToken: string): void {
+        this.authToken = newToken;
+    }
+
+    private async fetchLatestCommitSha(): Promise<string | null> {
+        const data: Array<EngineVerion> = await fetch(`${this.baseUrl}/studio-engine`, {
+            headers: {
+                Authorization: `Bearer ${this.authToken}`,
+                'Content-Type': 'application/json',
+            },
+        }).then((res) => res.json());
+        return data.find((v) => v.name === 'latest')?.successCommitHash ?? null;
+    }
+}

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -7,7 +7,9 @@ interface EngineVerion {
 
 export class EngineVersionManager {
     private readonly baseUrl = 'https://dev.devapi.chiligrafx-dev.com/version-management';
+
     private readonly CACHE_TTL = 120; // 2 minutes in seconds
+
     private authToken: string;
 
     constructor(authToken: string) {

--- a/src/_dev-execution/version-manager.ts
+++ b/src/_dev-execution/version-manager.ts
@@ -6,7 +6,7 @@ interface EngineVerion {
 }
 
 export class EngineVersionManager {
-    private readonly baseUrl = 'https://dev.devapi.chiligrafx-dev.com/version-management';
+    private readonly requestUrl = import.meta.env.VITE_ENGINE_VERSIONS_URL;
 
     private readonly CACHE_TTL = 60 * 60; // 1h (in seconds)
 
@@ -32,8 +32,11 @@ export class EngineVersionManager {
     }
 
     private async fetchLatestCommitSha(branchPath: string): Promise<string | null> {
+        if (!this.requestUrl) {
+            return null;
+        }
         const selected = branchPath === 'main' ? 'latest' : branchPath;
-        const data: Array<EngineVerion> = await fetch(`${this.baseUrl}/studio-engine`, {
+        const data: Array<EngineVerion> = await fetch(this.requestUrl, {
             headers: {
                 Authorization: `Bearer ${this.authToken}`,
                 'Content-Type': 'application/json',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 import { defineConfig } from 'vite';
-import EnvironmentPlugin from 'vite-plugin-environment';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {
@@ -10,7 +9,7 @@ export default ({ mode }) => {
         process.exit(1);
     }
     return defineConfig({
-        plugins: [react(), EnvironmentPlugin(['NODE_ENV', 'PREVIEW_ERROR_URL'])],
+        plugins: [react()],
         server: {
             port: 3002,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,11 +6548,6 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vite-plugin-environment@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz#d01a04abb2f69730a4866c9c9db51d3dab74645b"
-  integrity sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==
-
 vite@^4.3.9:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.0.tgz#ec406295b4167ac3bc23e26f9c8ff559287cff26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,6 +2214,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -4967,6 +4972,11 @@ jest@^29.5.0:
     "@jest/types" "^29.6.3"
     import-local "^3.0.2"
     jest-cli "^29.7.0"
+
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR brings addition possibility to fetch the commit sha for corresponding branch (main or pr) from our dev server in order to not provide it via the URL or via .env param

Note: the fetching works only when you don't specify hash in the URL, so the previous behaviour wasn't changed

## Related tickets

-   [WRS-NUMBER](https://chilipublishintranet.atlassian.net/browse/WRS-NUMBER)

## Screenshots
