### PR TITLE
[Fix] [WRR-2927] Improvements for patching old versions

### DIFF
--- a/.github/actions/create-gh-release/action.yml
+++ b/.github/actions/create-gh-release/action.yml
@@ -13,6 +13,10 @@ inputs:
     release_type:
         required: true
         description: 'Release type: uat or production'
+    skip_github_latest:
+        required: false
+        default: 'false'
+        description: 'Production only: when true, gh release create uses --latest=false (old-line PRD hotfix).'
 outputs:
     notification_text:
         description: 'Prepared notification text'
@@ -28,6 +32,7 @@ runs:
               PREVIOUS_TAG="${{ inputs.previous_tag }}"
               TARGET_REF="${{ inputs.target_ref }}"
               RELEASE_TYPE="${{ inputs.release_type }}"
+              SKIP_GITHUB_LATEST="${{ inputs.skip_github_latest }}"
 
               # UAT releases are prereleases, production releases are not
               if [ "$RELEASE_TYPE" = "uat" ]; then
@@ -38,11 +43,20 @@ runs:
                   --notes-start-tag "$PREVIOUS_TAG" \
                   --prerelease
               else
-                gh release create $TAG_NAME \
-                  --target $TARGET_REF \
-                  --title "$TAG_NAME" \
-                  --generate-notes \
-                  --notes-start-tag "$PREVIOUS_TAG"
+                if [ "$SKIP_GITHUB_LATEST" = "true" ]; then
+                  gh release create $TAG_NAME \
+                    --target $TARGET_REF \
+                    --title "$TAG_NAME" \
+                    --generate-notes \
+                    --notes-start-tag "$PREVIOUS_TAG" \
+                    --latest=false
+                else
+                  gh release create $TAG_NAME \
+                    --target $TARGET_REF \
+                    --title "$TAG_NAME" \
+                    --generate-notes \
+                    --notes-start-tag "$PREVIOUS_TAG"
+                fi
               fi
 
               RELEASE_URL=$(gh release view $TAG_NAME --json url -q '.url')

--- a/.github/actions/merge-and-delete-branch/action.yml
+++ b/.github/actions/merge-and-delete-branch/action.yml
@@ -1,5 +1,5 @@
 name: 'Merge and Delete Branch'
-description: 'Optionally merge source into target (--strategy=ours), then delete the source branch'
+description: 'Merge source into target (--strategy=ours), then delete the source branch'
 inputs:
     source_branch:
         required: true
@@ -7,15 +7,10 @@ inputs:
     target_branch:
         required: true
         description: 'Target branch to merge to'
-    merge_into_target:
-        required: false
-        default: 'true'
-        description: 'When false, skip merging source into target (e.g. old-line PRD hotfix); source branch is still deleted.'
 runs:
     using: composite
     steps:
         - name: Merge source branch to target branch
-          if: inputs.merge_into_target == 'true'
           shell: bash
           run: |
               SOURCE_BRANCH="${{ inputs.source_branch }}"
@@ -45,13 +40,7 @@ runs:
               SOURCE_BRANCH="${{ inputs.source_branch }}"
               TARGET_BRANCH="${{ inputs.target_branch }}"
 
-              # Ensure target exists locally (needed when merge step was skipped)
-              git fetch origin "$TARGET_BRANCH" || {
-                echo "❌ Failed to fetch target branch: $TARGET_BRANCH"
-                exit 1
-              }
-
-              # Checkout target branch first to avoid being on the branch we want to delete
+              # Checkout target (merge step left the repo on it; explicit checkout avoids deleting while on source)
               git checkout "$TARGET_BRANCH" || {
                 echo "⚠️  Failed to checkout target branch: $TARGET_BRANCH. Attempting to delete source branch anyway."
               }

--- a/.github/actions/merge-and-delete-branch/action.yml
+++ b/.github/actions/merge-and-delete-branch/action.yml
@@ -1,5 +1,5 @@
 name: 'Merge and Delete Branch'
-description: 'Merge source branch to target branch using --strategy=ours, then delete source branch'
+description: 'Optionally merge source into target (--strategy=ours), then delete the source branch'
 inputs:
     source_branch:
         required: true
@@ -7,10 +7,15 @@ inputs:
     target_branch:
         required: true
         description: 'Target branch to merge to'
+    merge_into_target:
+        required: false
+        default: 'true'
+        description: 'When false, skip merging source into target (e.g. old-line PRD hotfix); source branch is still deleted.'
 runs:
     using: composite
     steps:
         - name: Merge source branch to target branch
+          if: inputs.merge_into_target == 'true'
           shell: bash
           run: |
               SOURCE_BRANCH="${{ inputs.source_branch }}"
@@ -39,6 +44,12 @@ runs:
           run: |
               SOURCE_BRANCH="${{ inputs.source_branch }}"
               TARGET_BRANCH="${{ inputs.target_branch }}"
+
+              # Ensure target exists locally (needed when merge step was skipped)
+              git fetch origin "$TARGET_BRANCH" || {
+                echo "❌ Failed to fetch target branch: $TARGET_BRANCH"
+                exit 1
+              }
 
               # Checkout target branch first to avoid being on the branch we want to delete
               git checkout "$TARGET_BRANCH" || {

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -46,6 +46,8 @@ jobs:
         steps:
             - name: Prepare release parameters
               id: prepare
+              env:
+                  OLD_PRD_HOTFIX_BASE_TAG: ${{ github.event.inputs.old_prd_hotfix_base_tag }}
               run: |
                   # Read values from workflow_dispatch inputs (required)
                   if [ -z "${{ github.event.inputs.environment }}" ]; then
@@ -66,7 +68,6 @@ jobs:
                   fi
                   SDK_VERSION="${{ github.event.inputs.sdk_version }}"
 
-                  OLD_PRD_HOTFIX_BASE_TAG="${{ github.event.inputs.old_prd_hotfix_base_tag }}"
                   OLD_PRD_HOTFIX_BASE_TAG=$(echo "$OLD_PRD_HOTFIX_BASE_TAG" | xargs)
                   if [ -n "$OLD_PRD_HOTFIX_BASE_TAG" ]; then
                     if [ "$ENVIRONMENT" != "prd" ] || [ "$RELEASE_TYPE" != "hotfix" ]; then
@@ -382,10 +383,12 @@ jobs:
             - name: Validate old-line PRD base tag
               id: old_line_context
               if: needs.configure-parameters.outputs.old_prd_hotfix_base_tag != ''
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  OLD_PRD_HOTFIX_BASE_TAG: ${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag }}
               run: |
                   set -euo pipefail
-                  BASE_RAW="${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag }}"
-                  BASE_RAW=$(echo "$BASE_RAW" | xargs)
+                  BASE_RAW=$(echo "$OLD_PRD_HOTFIX_BASE_TAG" | xargs)
 
                   if ! [[ "$BASE_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                     echo "❌ Error: old_prd_hotfix_base_tag must be semver X.Y.Z (e.g. 1.37.2), got: $BASE_RAW"
@@ -440,8 +443,6 @@ jobs:
                   echo "base_normalized=$BASE_RAW" >> $GITHUB_OUTPUT
                   echo "previous_tag_for_notes=$TAG_FOR_NOTES" >> $GITHUB_OUTPUT
                   echo "✅ Old-line PRD base validated: $TAG_FOR_NOTES < global max $HIGHEST"
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Find previous release tag
               id: previous_tag

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,6 +21,11 @@ on:
                 description: "SDK version to use (e.g., 1.35.0 or 1.35.0-rc.0) or 'latest' to keep current version unchanged."
                 required: true
                 type: string
+            old_prd_hotfix_base_tag:
+                description: 'Optional. Old-line PRD hotfix only: existing stable PRD tag being patched (e.g. 1.37.2). Empty keeps current behavior.'
+                required: false
+                type: string
+                default: ''
 
 env:
     NODE_VERSION: 22.x
@@ -37,6 +42,7 @@ jobs:
             release_type: ${{ steps.prepare.outputs.release_type }}
             sdk_version: ${{ steps.prepare.outputs.sdk_version }}
             target_branch: ${{ steps.prepare.outputs.target_branch }}
+            old_prd_hotfix_base_tag: ${{ steps.prepare.outputs.old_prd_hotfix_base_tag }}
         steps:
             - name: Prepare release parameters
               id: prepare
@@ -60,6 +66,15 @@ jobs:
                   fi
                   SDK_VERSION="${{ github.event.inputs.sdk_version }}"
 
+                  OLD_PRD_HOTFIX_BASE_TAG="${{ github.event.inputs.old_prd_hotfix_base_tag }}"
+                  OLD_PRD_HOTFIX_BASE_TAG=$(echo "$OLD_PRD_HOTFIX_BASE_TAG" | xargs)
+                  if [ -n "$OLD_PRD_HOTFIX_BASE_TAG" ]; then
+                    if [ "$ENVIRONMENT" != "prd" ] || [ "$RELEASE_TYPE" != "hotfix" ]; then
+                      echo "❌ Error: old_prd_hotfix_base_tag may only be set when environment is prd and release_type is hotfix."
+                      exit 1
+                    fi
+                  fi
+
                   # Define target branch. It states for the branch that will be used for release commit history merges.
                   TARGET_BRANCH="main"
 
@@ -67,6 +82,7 @@ jobs:
                   echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
                   echo "sdk_version=$SDK_VERSION" >> $GITHUB_OUTPUT
                   echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+                  echo "old_prd_hotfix_base_tag=$OLD_PRD_HOTFIX_BASE_TAG" >> $GITHUB_OUTPUT
 
     uat-regular:
         needs: configure-parameters
@@ -285,6 +301,7 @@ jobs:
             version_commit_sha: ${{ steps.apply_version.outputs.version_commit_sha }}
             version_branch: ${{ steps.apply_version.outputs.version_branch }}
             previous_tag: ${{ steps.previous_tag.outputs.previous_tag }}
+            skip_github_latest: ${{ steps.old_line_context.outputs.skip_github_latest || 'false' }}
         steps:
             - name: Validate branch
               run: |
@@ -360,10 +377,63 @@ jobs:
 
                   echo "✅ UAT tag '$CURRENT_VERSION' found in GitHub releases"
 
+            # The following step will only run if old_prd_hotfix_base_tag is set
+            - name: Validate old-line PRD base tag
+              id: old_line_context
+              if: needs.configure-parameters.outputs.old_prd_hotfix_base_tag != ''
+              run: |
+                  set -euo pipefail
+                  BASE_RAW="${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag }}"
+                  BASE_RAW=$(echo "$BASE_RAW" | xargs)
+
+                  if ! [[ "$BASE_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "❌ Error: old_prd_hotfix_base_tag must be semver X.Y.Z (e.g. 1.37.2), got: $BASE_RAW"
+                    exit 1
+                  fi
+
+                  if ! REL_JSON=$(gh release view "$BASE_RAW" --json tagName,isDraft,prerelease 2>/dev/null); then
+                    echo "❌ Error: No GitHub release found for tag $BASE_RAW"
+                    exit 1
+                  fi
+
+                  TAG_FOR_NOTES=$(echo "$REL_JSON" | jq -r '.tagName')
+                  REPO="${{ github.repository }}"
+                  HIGHEST=$(gh api "repos/$REPO/releases" --paginate --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+                    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | sort -V \
+                    | tail -1)
+
+                  if [ -z "$HIGHEST" ]; then
+                    echo "❌ Error: Could not determine highest stable PRD version from GitHub releases."
+                    exit 1
+                  fi
+
+                  LOWEST=$(printf '%s\n%s\n' "$BASE_RAW" "$HIGHEST" | sort -V | head -1)
+                  if [ "$BASE_RAW" = "$HIGHEST" ] || [ "$LOWEST" != "$BASE_RAW" ]; then
+                    echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the global highest stable release ($HIGHEST)."
+                    echo "❌ If you are releasing the current line, leave old_prd_hotfix_base_tag empty."
+                    exit 1
+                  fi
+
+                  echo "is_old_line=true" >> $GITHUB_OUTPUT
+                  echo "skip_github_latest=true" >> $GITHUB_OUTPUT
+                  echo "base_normalized=$BASE_RAW" >> $GITHUB_OUTPUT
+                  echo "previous_tag_for_notes=$TAG_FOR_NOTES" >> $GITHUB_OUTPUT
+                  echo "✅ Old-line PRD base validated: $TAG_FOR_NOTES < global max $HIGHEST"
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Find previous release tag
               id: previous_tag
               run: |
                   RELEASES_FILE="${{ steps.fetch_releases.outputs.releases_file }}"
+
+                  if [ "${{ steps.old_line_context.outputs.is_old_line }}" = "true" ]; then
+                    PREVIOUS_TAG="${{ steps.old_line_context.outputs.previous_tag_for_notes }}"
+                    echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+                    echo "📎 Using old-line base as previous tag for release notes: $PREVIOUS_TAG"
+                    exit 0
+                  fi
 
                   # For PRD releases, always use the latest production release as previous tag
                   PREVIOUS_TAG=$(jq -r '.[] | select(.isPrerelease == false) | .tagName' "$RELEASES_FILE" | head -1)
@@ -381,6 +451,19 @@ jobs:
               uses: ./.github/actions/bump-version
               with:
                   version_strategy: 'patch'
+
+            - name: Assert old-line bump matches expected patch
+              if: steps.old_line_context.outputs.is_old_line == 'true'
+              run: |
+                  BASE="${{ steps.old_line_context.outputs.base_normalized }}"
+                  NEW_TAG="${{ steps.bump_version.outputs.tag_name }}"
+                  IFS=. read -r ma mi pa <<< "$BASE"
+                  EXPECTED="${ma}.${mi}.$((pa + 1))"
+                  if [ "$NEW_TAG" != "$EXPECTED" ]; then
+                    echo "❌ Error: Expected bumped tag $EXPECTED after base $BASE, got $NEW_TAG"
+                    exit 1
+                  fi
+                  echo "✅ Bumped tag $NEW_TAG matches expected patch after base $BASE"
 
             - name: Validate SDK version (production)
               run: |
@@ -622,6 +705,7 @@ jobs:
                     echo "version_branch=${{ needs.production.outputs.version_branch }}" >> $GITHUB_OUTPUT
                     echo "previous_tag=${{ needs.production.outputs.previous_tag }}" >> $GITHUB_OUTPUT
                     echo "version_commit_sha=${{ needs.production.outputs.version_commit_sha }}" >> $GITHUB_OUTPUT
+                    echo "skip_github_latest=${{ needs.production.outputs.skip_github_latest }}" >> $GITHUB_OUTPUT
                   fi
 
                   # Map environment to release_type for create-gh-release action
@@ -667,6 +751,7 @@ jobs:
                   previous_tag: ${{ steps.version.outputs.previous_tag }}
                   target_ref: ${{ steps.version.outputs.version_commit_sha }}
                   release_type: ${{ steps.version.outputs.release_type }}
+                  skip_github_latest: ${{ steps.version.outputs.skip_github_latest || 'false' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -392,12 +392,12 @@ jobs:
                     exit 1
                   fi
 
-                  if ! REL_JSON=$(gh release view "$BASE_RAW" --json tagName,isDraft,prerelease 2>/dev/null); then
+                  if ! REL_JSON=$(gh release view "$BASE_RAW" --json tagName,isDraft,isPrerelease 2>/dev/null); then
                     echo "❌ Error: No GitHub release found for tag $BASE_RAW"
                     exit 1
                   fi
                   IS_DRAFT=$(echo "$REL_JSON" | jq -r '.isDraft')
-                  IS_PRERELEASE=$(echo "$REL_JSON" | jq -r '.prerelease')
+                  IS_PRERELEASE=$(echo "$REL_JSON" | jq -r '.isPrerelease')
                   if [ "$IS_DRAFT" = "true" ]; then
                     echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is a draft release. Only finalized releases can be patched."
                     exit 1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ on:
                 required: true
                 type: string
             previous_prd_release_version:
-                description: 'Optional. Only for old-line PRD hotfix releases. Existing stable PRD version to patch (e.g. 1.37.2). Empty keeps current behavior.'
+                description: 'Optional. Only for old-line PRD hotfix. Stable PRD to patch (e.g. 1.37.2). Empty = current line. UAT old-line: deploy infers from tag vs GitHub latest.'
                 required: false
                 type: string
                 default: ''

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -395,6 +395,16 @@ jobs:
                     echo "❌ Error: No GitHub release found for tag $BASE_RAW"
                     exit 1
                   fi
+                  IS_DRAFT=$(echo "$REL_JSON" | jq -r '.isDraft')
+                  IS_PRERELEASE=$(echo "$REL_JSON" | jq -r '.prerelease')
+                  if [ "$IS_DRAFT" = "true" ]; then
+                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is a draft release. Only finalized releases can be patched."
+                    exit 1
+                  fi
+                  if [ "$IS_PRERELEASE" = "true" ]; then
+                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is a prerelease. Only stable PRD releases can be patched."
+                    exit 1
+                  fi
 
                   TAG_FOR_NOTES=$(echo "$REL_JSON" | jq -r '.tagName')
                   REPO="${{ github.repository }}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,11 +21,6 @@ on:
                 description: "SDK version to use (e.g., 1.35.0 or 1.35.0-rc.0) or 'latest' to keep current version unchanged."
                 required: true
                 type: string
-            previous_prd_release_version:
-                description: 'Optional. Only for old-line PRD hotfix. Stable PRD to patch (e.g. 1.37.2). Empty = current line. UAT old-line: deploy infers from tag vs GitHub latest.'
-                required: false
-                type: string
-                default: ''
 
 env:
     NODE_VERSION: 22.x
@@ -42,12 +37,9 @@ jobs:
             release_type: ${{ steps.prepare.outputs.release_type }}
             sdk_version: ${{ steps.prepare.outputs.sdk_version }}
             target_branch: ${{ steps.prepare.outputs.target_branch }}
-            previous_prd_release_version: ${{ steps.prepare.outputs.previous_prd_release_version }}
         steps:
             - name: Prepare release parameters
               id: prepare
-              env:
-                  PREVIOUS_PRD_RELEASE_VERSION: ${{ github.event.inputs.previous_prd_release_version }}
               run: |
                   # Read values from workflow_dispatch inputs (required)
                   if [ -z "${{ github.event.inputs.environment }}" ]; then
@@ -68,22 +60,13 @@ jobs:
                   fi
                   SDK_VERSION="${{ github.event.inputs.sdk_version }}"
 
-                  PREVIOUS_PRD_RELEASE_VERSION=$(echo "$PREVIOUS_PRD_RELEASE_VERSION" | xargs)
-                  if [ -n "$PREVIOUS_PRD_RELEASE_VERSION" ]; then
-                    if [ "$ENVIRONMENT" != "prd" ] || [ "$RELEASE_TYPE" != "hotfix" ]; then
-                      echo "❌ Error: previous_prd_release_version may only be set when environment is prd and release_type is hotfix."
-                      exit 1
-                    fi
-                  fi
-
-                  # Integration branch for branch-validation (UAT from main, PRD not from main). Merge-back uses target_branch unless previous_prd_release_version is set (finalize-release skips merge to main).
+                  # Integration branch for branch-validation (UAT from main, PRD not from main). Old-line is inferred per-job from package.json vs GitHub latest stable.
                   TARGET_BRANCH="main"
 
                   echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
                   echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
                   echo "sdk_version=$SDK_VERSION" >> $GITHUB_OUTPUT
                   echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
-                  echo "previous_prd_release_version=$PREVIOUS_PRD_RELEASE_VERSION" >> $GITHUB_OUTPUT
 
     uat-regular:
         needs: configure-parameters
@@ -351,8 +334,60 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+            # Detect old-line PRD purely from package.json vs the GitHub latest stable release.
+            # Old line = candidate stable (package.json with -rc* stripped) is on a different
+            # major.minor line than the current GitHub latest, AND strictly less than it.
+            - name: Detect old-line PRD
+              id: old_line_context
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+                  if [ -z "$CURRENT_VERSION" ]; then
+                    echo "❌ Error: Could not read version from package.json"
+                    exit 1
+                  fi
+                  CANDIDATE_STABLE="${CURRENT_VERSION%%-*}"
+                  if ! [[ "$CANDIDATE_STABLE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "❌ Error: Could not derive stable semver from package.json version: $CURRENT_VERSION"
+                    exit 1
+                  fi
+
+                  LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+                  if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ] || ! [[ "$LATEST_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "ℹ️ No valid GitHub latest stable; treating as current-line PRD"
+                    echo "is_old_line=false" >> $GITHUB_OUTPUT
+                    echo "skip_github_latest=false" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
+                  HIGHEST="$LATEST_TAG"
+
+                  BASE_LINE="${CANDIDATE_STABLE%.*}"
+                  HIGHEST_LINE="${HIGHEST%.*}"
+
+                  LOWEST=$(printf '%s\n%s\n' "$CANDIDATE_STABLE" "$HIGHEST" | sort -V | head -1)
+                  if [ "$BASE_LINE" != "$HIGHEST_LINE" ] && [ "$LOWEST" = "$CANDIDATE_STABLE" ] && [ "$CANDIDATE_STABLE" != "$HIGHEST" ]; then
+                    # Highest stable git tag on the same minor line (X.Y.Z, no prerelease suffix).
+                    PREVIOUS_ON_LINE=$(git tag --list "${BASE_LINE}.*" --sort=version:refname \
+                      | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" \
+                      | tail -n 1)
+                    if [ -z "$PREVIOUS_ON_LINE" ]; then
+                      echo "❌ Error: Old-line PRD detected ($CANDIDATE_STABLE on $BASE_LINE.x, latest $HIGHEST) but no previous stable git tag found on $BASE_LINE.x"
+                      exit 1
+                    fi
+                    echo "is_old_line=true" >> $GITHUB_OUTPUT
+                    echo "skip_github_latest=true" >> $GITHUB_OUTPUT
+                    echo "previous_tag_for_notes=$PREVIOUS_ON_LINE" >> $GITHUB_OUTPUT
+                    echo "✅ Old-line PRD: candidate $CANDIDATE_STABLE on $BASE_LINE.x, latest stable $HIGHEST; previous stable on line: $PREVIOUS_ON_LINE"
+                  else
+                    echo "is_old_line=false" >> $GITHUB_OUTPUT
+                    echo "skip_github_latest=false" >> $GITHUB_OUTPUT
+                    echo "ℹ️ Current-line PRD: candidate $CANDIDATE_STABLE, latest stable $HIGHEST"
+                  fi
+
             - name: Validate UAT tag exists
-              if: needs.configure-parameters.outputs.previous_prd_release_version == ''
+              if: steps.old_line_context.outputs.is_old_line != 'true'
               run: |
                   RELEASES_FILE="${{ steps.fetch_releases.outputs.releases_file }}"
 
@@ -378,71 +413,6 @@ jobs:
                   fi
 
                   echo "✅ UAT tag '$CURRENT_VERSION' found in GitHub releases"
-
-            # The following step will only run if previous_prd_release_version is set (old-line PRD)
-            - name: Validate old-line PRD base tag
-              id: old_line_context
-              if: needs.configure-parameters.outputs.previous_prd_release_version != ''
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PREVIOUS_PRD_RELEASE_VERSION: ${{ needs.configure-parameters.outputs.previous_prd_release_version }}
-              run: |
-                  set -euo pipefail
-                  BASE_RAW=$(echo "$PREVIOUS_PRD_RELEASE_VERSION" | xargs)
-
-                  if ! [[ "$BASE_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    echo "❌ Error: previous_prd_release_version must be semver X.Y.Z (e.g. 1.37.2), got: $BASE_RAW"
-                    exit 1
-                  fi
-
-                  if ! REL_JSON=$(gh release view "$BASE_RAW" --json tagName,isDraft,isPrerelease 2>/dev/null); then
-                    echo "❌ Error: No GitHub release found for tag $BASE_RAW"
-                    exit 1
-                  fi
-                  IS_DRAFT=$(echo "$REL_JSON" | jq -r '.isDraft')
-                  IS_PRERELEASE=$(echo "$REL_JSON" | jq -r '.isPrerelease')
-                  if [ "$IS_DRAFT" = "true" ]; then
-                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is a draft release. Only finalized releases can be patched."
-                    exit 1
-                  fi
-                  if [ "$IS_PRERELEASE" = "true" ]; then
-                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is a prerelease. Only stable PRD releases can be patched."
-                    exit 1
-                  fi
-
-                  TAG_FOR_NOTES=$(echo "$REL_JSON" | jq -r '.tagName')
-                  LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
-                  if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
-                    echo "❌ Error: Could not determine latest release tag (gh release view)."
-                    exit 1
-                  fi
-                  if ! [[ "$LATEST_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    echo "❌ Error: Latest release tag must be semver X.Y.Z for this check, got: $LATEST_TAG"
-                    exit 1
-                  fi
-                  HIGHEST="$LATEST_TAG"
-
-                  # We need to make sure that the entered version (BASE_RAW) is strictly less than the current latest stable release
-                  # LOWEST is min(base, highest)
-                  LOWEST=$(printf '%s\n%s\n' "$BASE_RAW" "$HIGHEST" | sort -V | head -1)
-                  if [ "$BASE_RAW" = "$HIGHEST" ] || [ "$LOWEST" != "$BASE_RAW" ]; then
-                    echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the current latest stable release ($HIGHEST)."
-                    echo "❌ If you are releasing the current line, leave previous_prd_release_version empty."
-                    exit 1
-                  fi
-
-                  BASE_LINE="${BASE_RAW%.*}"
-                  HIGHEST_LINE="${HIGHEST%.*}"
-                  if [ "$BASE_LINE" = "$HIGHEST_LINE" ]; then
-                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is on the current release line ($HIGHEST_LINE). Leave it empty for current-line hotfixes."
-                    exit 1
-                  fi
-
-                  echo "is_old_line=true" >> $GITHUB_OUTPUT
-                  echo "skip_github_latest=true" >> $GITHUB_OUTPUT
-                  echo "base_normalized=$BASE_RAW" >> $GITHUB_OUTPUT
-                  echo "previous_tag_for_notes=$TAG_FOR_NOTES" >> $GITHUB_OUTPUT
-                  echo "✅ Old-line PRD base validated: $TAG_FOR_NOTES < latest $LATEST_TAG"
 
             - name: Find previous release tag
               id: previous_tag
@@ -476,7 +446,7 @@ jobs:
             - name: Assert old-line bump matches expected patch
               if: steps.old_line_context.outputs.is_old_line == 'true'
               run: |
-                  BASE="${{ steps.old_line_context.outputs.base_normalized }}"
+                  BASE="${{ steps.old_line_context.outputs.previous_tag_for_notes }}"
                   NEW_TAG="${{ steps.bump_version.outputs.tag_name }}"
                   IFS=. read -r ma mi pa <<< "$BASE"
                   EXPECTED="${ma}.${mi}.$((pa + 1))"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -411,22 +411,22 @@ jobs:
                   fi
 
                   TAG_FOR_NOTES=$(echo "$REL_JSON" | jq -r '.tagName')
-                  REPO="${{ github.repository }}"
-                  HIGHEST=$(gh api "repos/$REPO/releases" --paginate --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
-                    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-                    | sort -V \
-                    | tail -1)
-
-                  if [ -z "$HIGHEST" ]; then
-                    echo "❌ Error: Could not determine highest stable PRD version from GitHub releases."
+                  LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+                  if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+                    echo "❌ Error: Could not determine latest release tag (gh release view)."
                     exit 1
                   fi
+                  if ! [[ "$LATEST_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "❌ Error: Latest release tag must be semver X.Y.Z for this check, got: $LATEST_TAG"
+                    exit 1
+                  fi
+                  HIGHEST="$LATEST_TAG"
 
-                  # We need to make sure that the entered version (BASE_RAW) is strictly less than the global highest stable release
+                  # We need to make sure that the entered version (BASE_RAW) is strictly less than the current latest stable release
                   # LOWEST is min(base, highest)
                   LOWEST=$(printf '%s\n%s\n' "$BASE_RAW" "$HIGHEST" | sort -V | head -1)
                   if [ "$BASE_RAW" = "$HIGHEST" ] || [ "$LOWEST" != "$BASE_RAW" ]; then
-                    echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the global highest stable release ($HIGHEST)."
+                    echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the current latest stable release ($HIGHEST)."
                     echo "❌ If you are releasing the current line, leave previous_prd_release_version empty."
                     exit 1
                   fi
@@ -442,7 +442,7 @@ jobs:
                   echo "skip_github_latest=true" >> $GITHUB_OUTPUT
                   echo "base_normalized=$BASE_RAW" >> $GITHUB_OUTPUT
                   echo "previous_tag_for_notes=$TAG_FOR_NOTES" >> $GITHUB_OUTPUT
-                  echo "✅ Old-line PRD base validated: $TAG_FOR_NOTES < global max $HIGHEST"
+                  echo "✅ Old-line PRD base validated: $TAG_FOR_NOTES < latest $LATEST_TAG"
 
             - name: Find previous release tag
               id: previous_tag

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -781,7 +781,6 @@ jobs:
               with:
                   source_branch: ${{ steps.version.outputs.version_branch }}
                   target_branch: ${{ needs.configure-parameters.outputs.target_branch }}
-                  merge_into_target: ${{ needs.configure-parameters.outputs.previous_prd_release_version == '' && 'true' || 'false' }}
               env:
                   GITHUB_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -428,6 +428,13 @@ jobs:
                     exit 1
                   fi
 
+                  BASE_LINE="${BASE_RAW%.*}"
+                  HIGHEST_LINE="${HIGHEST%.*}"
+                  if [ "$BASE_LINE" = "$HIGHEST_LINE" ]; then
+                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is on the current release line ($HIGHEST_LINE). Leave it empty for current-line hotfixes."
+                    exit 1
+                  fi
+
                   echo "is_old_line=true" >> $GITHUB_OUTPUT
                   echo "skip_github_latest=true" >> $GITHUB_OUTPUT
                   echo "base_normalized=$BASE_RAW" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -75,7 +75,7 @@ jobs:
                     fi
                   fi
 
-                  # Define target branch. It states for the branch that will be used for release commit history merges.
+                  # Integration branch for branch-validation (UAT from main, PRD not from main). Merge-back uses target_branch below unless old_prd_hotfix_base_tag is set (finalize-release skips merge to main).
                   TARGET_BRANCH="main"
 
                   echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
@@ -780,6 +780,7 @@ jobs:
               with:
                   source_branch: ${{ steps.version.outputs.version_branch }}
                   target_branch: ${{ needs.configure-parameters.outputs.target_branch }}
+                  merge_into_target: ${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag == '' && 'true' || 'false' }}
               env:
                   GITHUB_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,8 +21,8 @@ on:
                 description: "SDK version to use (e.g., 1.35.0 or 1.35.0-rc.0) or 'latest' to keep current version unchanged."
                 required: true
                 type: string
-            old_prd_hotfix_base_tag:
-                description: 'Optional. Old-line PRD hotfix only: existing stable PRD tag being patched (e.g. 1.37.2). Empty keeps current behavior.'
+            previous_prd_release_version:
+                description: 'Optional. Only for old-line PRD hotfix releases. Existing stable PRD version to patch (e.g. 1.37.2). Empty keeps current behavior.'
                 required: false
                 type: string
                 default: ''
@@ -42,12 +42,12 @@ jobs:
             release_type: ${{ steps.prepare.outputs.release_type }}
             sdk_version: ${{ steps.prepare.outputs.sdk_version }}
             target_branch: ${{ steps.prepare.outputs.target_branch }}
-            old_prd_hotfix_base_tag: ${{ steps.prepare.outputs.old_prd_hotfix_base_tag }}
+            previous_prd_release_version: ${{ steps.prepare.outputs.previous_prd_release_version }}
         steps:
             - name: Prepare release parameters
               id: prepare
               env:
-                  OLD_PRD_HOTFIX_BASE_TAG: ${{ github.event.inputs.old_prd_hotfix_base_tag }}
+                  PREVIOUS_PRD_RELEASE_VERSION: ${{ github.event.inputs.previous_prd_release_version }}
               run: |
                   # Read values from workflow_dispatch inputs (required)
                   if [ -z "${{ github.event.inputs.environment }}" ]; then
@@ -68,22 +68,22 @@ jobs:
                   fi
                   SDK_VERSION="${{ github.event.inputs.sdk_version }}"
 
-                  OLD_PRD_HOTFIX_BASE_TAG=$(echo "$OLD_PRD_HOTFIX_BASE_TAG" | xargs)
-                  if [ -n "$OLD_PRD_HOTFIX_BASE_TAG" ]; then
+                  PREVIOUS_PRD_RELEASE_VERSION=$(echo "$PREVIOUS_PRD_RELEASE_VERSION" | xargs)
+                  if [ -n "$PREVIOUS_PRD_RELEASE_VERSION" ]; then
                     if [ "$ENVIRONMENT" != "prd" ] || [ "$RELEASE_TYPE" != "hotfix" ]; then
-                      echo "❌ Error: old_prd_hotfix_base_tag may only be set when environment is prd and release_type is hotfix."
+                      echo "❌ Error: previous_prd_release_version may only be set when environment is prd and release_type is hotfix."
                       exit 1
                     fi
                   fi
 
-                  # Integration branch for branch-validation (UAT from main, PRD not from main). Merge-back uses target_branch below unless old_prd_hotfix_base_tag is set (finalize-release skips merge to main).
+                  # Integration branch for branch-validation (UAT from main, PRD not from main). Merge-back uses target_branch unless previous_prd_release_version is set (finalize-release skips merge to main).
                   TARGET_BRANCH="main"
 
                   echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
                   echo "release_type=$RELEASE_TYPE" >> $GITHUB_OUTPUT
                   echo "sdk_version=$SDK_VERSION" >> $GITHUB_OUTPUT
                   echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
-                  echo "old_prd_hotfix_base_tag=$OLD_PRD_HOTFIX_BASE_TAG" >> $GITHUB_OUTPUT
+                  echo "previous_prd_release_version=$PREVIOUS_PRD_RELEASE_VERSION" >> $GITHUB_OUTPUT
 
     uat-regular:
         needs: configure-parameters
@@ -352,7 +352,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Validate UAT tag exists
-              if: needs.configure-parameters.outputs.old_prd_hotfix_base_tag == ''
+              if: needs.configure-parameters.outputs.previous_prd_release_version == ''
               run: |
                   RELEASES_FILE="${{ steps.fetch_releases.outputs.releases_file }}"
 
@@ -379,19 +379,19 @@ jobs:
 
                   echo "✅ UAT tag '$CURRENT_VERSION' found in GitHub releases"
 
-            # The following step will only run if old_prd_hotfix_base_tag is set
+            # The following step will only run if previous_prd_release_version is set (old-line PRD)
             - name: Validate old-line PRD base tag
               id: old_line_context
-              if: needs.configure-parameters.outputs.old_prd_hotfix_base_tag != ''
+              if: needs.configure-parameters.outputs.previous_prd_release_version != ''
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  OLD_PRD_HOTFIX_BASE_TAG: ${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag }}
+                  PREVIOUS_PRD_RELEASE_VERSION: ${{ needs.configure-parameters.outputs.previous_prd_release_version }}
               run: |
                   set -euo pipefail
-                  BASE_RAW=$(echo "$OLD_PRD_HOTFIX_BASE_TAG" | xargs)
+                  BASE_RAW=$(echo "$PREVIOUS_PRD_RELEASE_VERSION" | xargs)
 
                   if ! [[ "$BASE_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    echo "❌ Error: old_prd_hotfix_base_tag must be semver X.Y.Z (e.g. 1.37.2), got: $BASE_RAW"
+                    echo "❌ Error: previous_prd_release_version must be semver X.Y.Z (e.g. 1.37.2), got: $BASE_RAW"
                     exit 1
                   fi
 
@@ -402,11 +402,11 @@ jobs:
                   IS_DRAFT=$(echo "$REL_JSON" | jq -r '.isDraft')
                   IS_PRERELEASE=$(echo "$REL_JSON" | jq -r '.isPrerelease')
                   if [ "$IS_DRAFT" = "true" ]; then
-                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is a draft release. Only finalized releases can be patched."
+                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is a draft release. Only finalized releases can be patched."
                     exit 1
                   fi
                   if [ "$IS_PRERELEASE" = "true" ]; then
-                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is a prerelease. Only stable PRD releases can be patched."
+                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is a prerelease. Only stable PRD releases can be patched."
                     exit 1
                   fi
 
@@ -427,14 +427,14 @@ jobs:
                   LOWEST=$(printf '%s\n%s\n' "$BASE_RAW" "$HIGHEST" | sort -V | head -1)
                   if [ "$BASE_RAW" = "$HIGHEST" ] || [ "$LOWEST" != "$BASE_RAW" ]; then
                     echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the global highest stable release ($HIGHEST)."
-                    echo "❌ If you are releasing the current line, leave old_prd_hotfix_base_tag empty."
+                    echo "❌ If you are releasing the current line, leave previous_prd_release_version empty."
                     exit 1
                   fi
 
                   BASE_LINE="${BASE_RAW%.*}"
                   HIGHEST_LINE="${HIGHEST%.*}"
                   if [ "$BASE_LINE" = "$HIGHEST_LINE" ]; then
-                    echo "❌ Error: old_prd_hotfix_base_tag ($BASE_RAW) is on the current release line ($HIGHEST_LINE). Leave it empty for current-line hotfixes."
+                    echo "❌ Error: previous_prd_release_version ($BASE_RAW) is on the current release line ($HIGHEST_LINE). Leave it empty for current-line hotfixes."
                     exit 1
                   fi
 
@@ -781,7 +781,7 @@ jobs:
               with:
                   source_branch: ${{ steps.version.outputs.version_branch }}
                   target_branch: ${{ needs.configure-parameters.outputs.target_branch }}
-                  merge_into_target: ${{ needs.configure-parameters.outputs.old_prd_hotfix_base_tag == '' && 'true' || 'false' }}
+                  merge_into_target: ${{ needs.configure-parameters.outputs.previous_prd_release_version == '' && 'true' || 'false' }}
               env:
                   GITHUB_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -351,6 +351,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Validate UAT tag exists
+              if: needs.configure-parameters.outputs.old_prd_hotfix_base_tag == ''
               run: |
                   RELEASES_FILE="${{ steps.fetch_releases.outputs.releases_file }}"
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -418,6 +418,8 @@ jobs:
                     exit 1
                   fi
 
+                  # We need to make sure that the entered version (BASE_RAW) is strictly less than the global highest stable release
+                  # LOWEST is min(base, highest)
                   LOWEST=$(printf '%s\n%s\n' "$BASE_RAW" "$HIGHEST" | sort -V | head -1)
                   if [ "$BASE_RAW" = "$HIGHEST" ] || [ "$LOWEST" != "$BASE_RAW" ]; then
                     echo "❌ Error: Old-line hotfix requires base ($BASE_RAW) to be strictly less than the global highest stable release ($HIGHEST)."

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -97,8 +97,36 @@ jobs:
               id: global_latest
               run: |
                   if [ "${{ steps.detect.outputs.is_prd }}" != "true" ]; then
-                    echo "update_global_latest=true" >> $GITHUB_OUTPUT
-                    echo "Non-PRD release: always update upload/latest"
+                    # UAT: set global upload/latest only when this UAT's base semver (tag without -rc) is >=
+                    # GitHub latest stable (gh release view). If UAT base < latest, treat as old-line: skip
+                    # upload/latest only; versioned upload/MAJ.MIN/.../ and .../MAJ.MIN/latest still update.
+                    TAG_NAME=${GITHUB_REF#refs/tags/}
+                    VER="${TAG_NAME#v}"
+                    UAT_BASE="${VER%%-rc*}"
+                    if ! echo "$UAT_BASE" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                      echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                      echo "UAT: could not parse base semver from $TAG_NAME; defaulting to update global upload/latest"
+                      exit 0
+                    fi
+                    LATEST_STABLE_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+                    CLEANED=$(printf '%s\n' "$LATEST_STABLE_TAG" | sed 's/^v//')
+                    LATEST=""
+                    if [ -n "$CLEANED" ] && echo "$CLEANED" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                      LATEST=$CLEANED
+                    fi
+                    if [ -z "$LATEST" ]; then
+                      echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                      echo "UAT: no valid GitHub latest stable; defaulting to update global upload/latest"
+                      exit 0
+                    fi
+                    MIN_VER=$(printf '%s\n' "$UAT_BASE" "$LATEST" | sort -V | head -1)
+                    if [ "$MIN_VER" = "$UAT_BASE" ] && [ "$UAT_BASE" != "$LATEST" ]; then
+                      echo "update_global_latest=false" >> $GITHUB_OUTPUT
+                      echo "UAT: $UAT_BASE < latest stable $LATEST; skipping only upload/latest (versioned paths still updated)"
+                    else
+                      echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                      echo "UAT: $UAT_BASE >= or same line as latest $LATEST; updating global upload/latest"
+                    fi
                     exit 0
                   fi
 
@@ -186,7 +214,7 @@ jobs:
                   if [ "$UPDATE_GLOBAL_LATEST" = "true" ]; then
                     cp -R dist/* ${latestPath%"/merge"}
                   else
-                    echo "Skipping global upload/latest (not GitHub latest PRD)"
+                    echo "Skipping global upload/latest (PRD: not GitHub latest; or UAT: old release line)"
                   fi
                   cp -R dist/* ${versionedLatestPath%"/merge"}
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -58,6 +58,7 @@ jobs:
             subscription_id: ${{ steps.detect.outputs.subscription_id }}
             storage_account_name: ${{ steps.detect.outputs.storage_account_name }}
             purge_destination: ${{ steps.detect.outputs.purge_destination }}
+            update_global_latest: ${{ steps.global_latest.outputs.update_global_latest }}
         steps:
             - name: Detect release type
               id: detect
@@ -91,6 +92,37 @@ jobs:
                   # Extract version from tag (remove v prefix if present)
                   VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+            - name: Compute global latest for CDN / main bump
+              id: global_latest
+              run: |
+                  if [ "${{ steps.detect.outputs.is_prd }}" != "true" ]; then
+                    echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                    echo "Non-PRD release: always update upload/latest"
+                    exit 0
+                  fi
+
+                  VERSION="${{ steps.detect.outputs.version }}"
+                  HIGHEST=$(gh api "repos/${{ github.repository }}/releases" --paginate --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+                    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | sort -V \
+                    | tail -1)
+
+                  if [ -z "$HIGHEST" ]; then
+                    echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                    echo "No stable semver releases found; updating upload/latest"
+                    exit 0
+                  fi
+
+                  if [ "$VERSION" = "$HIGHEST" ]; then
+                    echo "update_global_latest=true" >> $GITHUB_OUTPUT
+                    echo "PRD tag $VERSION is global highest stable; will update upload/latest and allow main bump"
+                  else
+                    echo "update_global_latest=false" >> $GITHUB_OUTPUT
+                    echo "PRD tag $VERSION is below global highest stable ($HIGHEST); skipping global upload/latest and main bump"
+                  fi
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     deploy-azure:
         needs: [validate-tag-release, detect-release-type]
@@ -147,7 +179,12 @@ jobs:
                   mkdir -p ${versionedLatestPath%"/merge"}
 
                   cp -R dist/* ${buildPath%"/merge"}
-                  cp -R dist/* ${latestPath%"/merge"}
+                  UPDATE_GLOBAL_LATEST="${{ needs.detect-release-type.outputs.update_global_latest }}"
+                  if [ "$UPDATE_GLOBAL_LATEST" = "true" ]; then
+                    cp -R dist/* ${latestPath%"/merge"}
+                  else
+                    echo "Skipping global upload/latest (old-line PRD tag)"
+                  fi
                   cp -R dist/* ${versionedLatestPath%"/merge"}
 
             - name: Azure Login
@@ -224,7 +261,7 @@ jobs:
 
     bump-main-version:
         needs: [validate-tag-release, detect-release-type, deploy-azure]
-        if: needs.validate-tag-release.outputs.release_exists == 'true' && needs.detect-release-type.outputs.is_prd == 'true'
+        if: needs.validate-tag-release.outputs.release_exists == 'true' && needs.detect-release-type.outputs.is_prd == 'true' && needs.detect-release-type.outputs.update_global_latest == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -103,23 +103,26 @@ jobs:
                   fi
 
                   VERSION="${{ steps.detect.outputs.version }}"
-                  HIGHEST=$(gh api "repos/${{ github.repository }}/releases" --paginate --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
-                    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-                    | sort -V \
-                    | tail -1)
+                  # GitHub "latest" full release (marked as latest, not UAT not old-line)
+                  LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+                  CLEANED=$(printf '%s\n' "$LATEST_TAG" | sed 's/^v//')
+                  HIGHEST=""
+                  if [ -n "$CLEANED" ] && echo "$CLEANED" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                    HIGHEST=$CLEANED
+                  fi
 
                   if [ -z "$HIGHEST" ]; then
                     echo "update_global_latest=true" >> $GITHUB_OUTPUT
-                    echo "No stable semver releases found; updating upload/latest"
+                    echo "No valid semver for GitHub latest release; updating upload/latest"
                     exit 0
                   fi
 
                   if [ "$VERSION" = "$HIGHEST" ]; then
                     echo "update_global_latest=true" >> $GITHUB_OUTPUT
-                    echo "PRD tag $VERSION is global highest stable; will update upload/latest and allow main bump"
+                    echo "PRD tag $VERSION is GitHub latest; will update upload/latest and allow main bump"
                   else
                     echo "update_global_latest=false" >> $GITHUB_OUTPUT
-                    echo "PRD tag $VERSION is below global highest stable ($HIGHEST); skipping global upload/latest and main bump"
+                    echo "PRD tag $VERSION is not GitHub latest ($HIGHEST); skipping global upload/latest and main bump"
                   fi
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +186,7 @@ jobs:
                   if [ "$UPDATE_GLOBAL_LATEST" = "true" ]; then
                     cp -R dist/* ${latestPath%"/merge"}
                   else
-                    echo "Skipping global upload/latest (old-line PRD tag)"
+                    echo "Skipping global upload/latest (not GitHub latest PRD)"
                   fi
                   cp -R dist/* ${versionedLatestPath%"/merge"}
 


### PR DESCRIPTION
This PR adds improvements to be able to patch old versions


## Release scenarios

> Starting state: latest stable PRD is `1.40.0`, main is `1.41.0-alpha.1`, latest UAT is `1.41.0-rc.0`.

| Scenario | Trigger branch | Tag produced | Release notes `previous_tag` | GitHub "Latest" | CDN `upload/latest` | CDN `upload/X.Y/latest` | Main branch bump |
|---|---|---|---|---|---|---|---|
| **UAT regular** | `main` | `1.41.0-rc.0` | `1.40.0` (highest stable PRD) | ✅ Yes (prerelease, always) | ✅ Yes | ✅ Yes (`upload/1.41/latest`) | ❌ No |
| **UAT hotfix** | hotfix branch off `1.41.0-rc.0` | `1.41.0-rc.1` | `1.41.0-rc.0` (tag the branch was cut from) | ✅ Yes (prerelease, always) | ✅ Yes | ✅ Yes (`upload/1.41/latest`) | ❌ No |
| **PRD regular** | release branch off `1.41.0-rc.1` | `1.41.0` | `1.40.0` (highest stable PRD below new tag) | ✅ Yes (`1.41.0` is global max) | ✅ Yes | ✅ Yes (`upload/1.41/latest`) | ✅ Yes → main bumped to `1.42.0-alpha.0` |
| **PRD hotfix (current line)** | hotfix branch off `1.41.0` | `1.41.1` | `1.41.0` (highest stable PRD below new tag) | ✅ Yes (`1.41.1` is global max) | ✅ Yes | ✅ Yes (`upload/1.41/latest`) | ❌ No (same `major.minor` as predecessor — patch only) |
| **PRD hotfix (old line `1.37.x`)** | hotfix branch off `1.37.1` | `1.37.2` | `1.37.1` (highest stable PRD below `1.37.2`) | ❌ No (`1.41.1` is higher) | ❌ No (`1.41.1` is higher) | ✅ Yes (`upload/1.37/latest`) | ❌ No (`1.41.1` is higher → not global max) |

## Related tickets

-   [WRS-2927](https://chilipublishintranet.atlassian.net/browse/WRS-2927)

## Screenshots


[WRS-2927]: https://chilipublishintranet.atlassian.net/browse/WRS-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ