### PR TITLE
[MAIN-2619] Expose validateVariables on the StudioUI instance

### DIFF
--- a/documentation/advanced-integration.md
+++ b/documentation/advanced-integration.md
@@ -665,3 +665,41 @@ By default, connector query calls are cached. This behavior can be overridden us
 `await StudioUISDK.configuration.setValue('ENABLE_QUERY_CALL_CACHE', status)`
 
 Here, status is a string — if sent as 'true', query calls will be cached; if 'false', they will not be cached.
+
+### Host-triggered variable validation (`validateVariables`)
+
+`studioUILoaderConfig` (and the other loaders) return a `StudioUI` instance. Besides `destroy()`, that instance exposes an imperative method that lets a host application validate all variables and gate its own flow:
+
+```typescript
+validateVariables(): Promise<Array<{ id: string }>>;
+```
+
+Calling it runs the **same validation the Download button performs**: it sweeps every currently visible variable and marks any field that is `required` but left empty with its error message and red styling. It then returns the list of variables that failed — one `{ id }` per failing field. An empty array means there are no errors, so the host can gate on `result.length`.
+
+This is useful when you build your own "Save"/"Submit"/"Next step" button outside Studio UI and want to (a) block the workflow until required variables are filled, and (b) show the user exactly which fields are missing — without re-implementing validation yourself.
+
+```js
+const ui = window.StudioUI.studioUILoaderConfig({
+    /* ... config ... */
+});
+
+async function onHostSubmit() {
+    const invalid = await ui.validateVariables();
+    if (invalid.length) {
+        // The required-but-empty fields are now highlighted red in the Studio UI form.
+        // `invalid` is e.g. [{ id: 'var-a' }, { id: 'var-c' }].
+        // Look up names/values from the engine SDK if you want to show your own summary:
+        // const v = await window.StudioUISDK.variable.getById(invalid[0].id);
+        return; // do not proceed with the host workflow
+    }
+    await myHostSubmit();
+}
+```
+
+Notes:
+
+- **Idempotent.** Calling it again after values change re-evaluates every visible field, so fields that have since been filled are automatically un-flagged. There is no separate "clear validation" method — re-running `validateVariables()` (or the user fixing a field and blurring it) clears resolved errors.
+- **Readiness.** It is meaningful only after the project has loaded (after your `onProjectLoaded` callback fires). Called before any variables exist — or after `destroy()` — it is a safe no-op and returns `[]`.
+- **Resolving variable details.** Each element is an object (`{ id }`) rather than a plain string, leaving room for additional fields in future. Use the engine SDK (`window.StudioUISDK.variable.*`) to resolve a variable's name/label/value from its id — the UI label can be a translation key, so `id` is the only unambiguous identifier.
+- **Known limitation — image variables.** A `required` image variable passes validation as soon as it has an asset id; this method does not verify that the image actually resolves, downloads, or renders. A required-but-broken image therefore reports as valid here. Use the SDK media-connector to probe if you need true load verification.
+- **Known limitation — DataSource variables.** A `required` DataSource variable with no selected row fails validation and is reported in the returned array, but it is not visually flagged in the form today — unlike text variables, it receives no red styling or inline error message. The host still gets its `id` in the result, so you can surface the missing field yourself.

--- a/src/deprecated-loaders.tsx
+++ b/src/deprecated-loaders.tsx
@@ -17,6 +17,8 @@ export type AppConfig = {
 export default class StudioUILoader {
     protected root: Root | undefined;
 
+    protected store: ReturnType<typeof setupStore> | undefined;
+
     constructor(selector: string, projectConfig: ProjectConfig, appConfig: AppConfig = {}) {
         const container = document.getElementById(selector || 'sui-root');
 
@@ -26,13 +28,13 @@ export default class StudioUILoader {
             );
         }
 
-        const store = setupStore({
+        this.store = setupStore({
             appConfig,
         });
         this.root = createRoot(container!);
         this.root.render(
             <React.StrictMode>
-                <Provider store={store}>
+                <Provider store={this.store}>
                     <App projectConfig={projectConfig} />
                 </Provider>
             </React.StrictMode>,
@@ -45,6 +47,7 @@ export default class StudioUILoader {
             console.warn('Destroying Studio UI component...');
             this.root.unmount();
             this.root = undefined;
+            this.store = undefined;
         }
     }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -47,7 +47,7 @@ export default class StudioUI extends StudioUILoader {
         }
         const { validation } = await this.store.dispatch(validateVariableList()).unwrap();
         return Object.entries(validation)
-            .filter(([, v]) => Boolean(v.errorMsg))
+            .filter(([, v]) => !!v.errorMsg)
             .map(([id]) => ({ id }));
     }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,11 +12,44 @@ import {
     ProjectConfig,
 } from './types/types';
 import { validateCoreConfig } from './utils/validateConfig';
+import { validateVariableList } from './store/reducers/variableReducer';
 
 export default class StudioUI extends StudioUILoader {
     protected root: Root | undefined;
 
     private static instance: StudioUI | undefined;
+
+    /**
+     * Validates all currently visible variables and shows the error state on any
+     * field that is required but left empty. This is the same validation the
+     * Download button performs, exposed for host applications that want to gate
+     * their own flow (e.g. a custom "Save" or "Submit" button) before proceeding.
+     *
+     * Calling this updates the UI immediately: every required-but-empty field is
+     * marked with its error message and red styling. Fields that are hidden
+     * (`isVisible === false`) are ignored.
+     *
+     * The method is idempotent: calling it again after values change re-evaluates
+     * every visible field, so fields that have since been filled are un-flagged.
+     *
+     * @returns A promise resolving to the list of variables that failed validation,
+     *  one `{ id }` per failing field. An **empty array means no errors** (the host
+     *  can gate on `result.length`).
+     *
+     * @remarks Meaningful only after the project has loaded (i.e. after the
+     *  `onProjectLoaded` config callback has fired). Called earlier, before any
+     *  variables exist in the store, or after `destroy()`, it is a safe no-op and
+     *  returns `[]`.
+     */
+    public async validateVariables(): Promise<Array<{ id: string }>> {
+        if (!this.store) {
+            return [];
+        }
+        const { validation } = await this.store.dispatch(validateVariableList()).unwrap();
+        return Object.entries(validation)
+            .filter(([, v]) => Boolean(v.errorMsg))
+            .map(([id]) => ({ id }));
+    }
 
     /**
      * Creates a new instance of StudioUI with all integration points available.

--- a/src/store/reducers/variableReducer.ts
+++ b/src/store/reducers/variableReducer.ts
@@ -32,7 +32,7 @@ export const validateVariableList = createAsyncThunk('variable/validateVariableL
     const { variable } = getState() as RootState;
     let hasErrors = false;
 
-    const validation = variable.variables.reduce((acc, current) => {
+    const validation = variable.variables.reduce<VariableValidation>((acc, current) => {
         if (!current.isVisible) return acc;
         const errMsg = getVariableErrMsg(current);
         if (errMsg) hasErrors = true;

--- a/src/tests/integration/ValidateVariables.test.tsx
+++ b/src/tests/integration/ValidateVariables.test.tsx
@@ -1,0 +1,161 @@
+import '@tests/mocks/sdk.mock';
+import { ShortTextVariable } from '@chili-publish/studio-sdk';
+import { mockUserInterface, mockApiUserInterface } from '@mocks/mockUserinterface';
+import { mockOutputSetting, mockOutputSetting2 } from '@mocks/mockOutputSetting';
+import { mockProject } from '@mocks/mockProject';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { variables } from '@tests/mocks/mockVariables';
+import StudioUI from '../../main';
+
+// Mock ProjectDataClient
+jest.mock('../../services/ProjectDataClient', () => ({
+    ProjectDataClient: jest.fn().mockImplementation(() => ({
+        fetchFromUrl: jest.fn().mockResolvedValue('{"test": "document"}'),
+        saveToUrl: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+// Mock EnvironmentApiService
+jest.mock('../../services/EnvironmentApiService', () => ({
+    EnvironmentApiService: {
+        create: jest.fn().mockImplementation(() => ({
+            getProjectById: jest.fn().mockResolvedValue(mockProject),
+            getProjectDocument: jest.fn().mockResolvedValue({ data: '{"test": "document"}' }),
+            saveProjectDocument: jest.fn().mockResolvedValue({ success: true }),
+            getAllUserInterfaces: jest.fn().mockResolvedValue({ data: [mockApiUserInterface] }),
+            getUserInterfaceById: jest.fn().mockResolvedValue(mockApiUserInterface),
+            getOutputSettings: jest.fn().mockResolvedValue({ data: [mockOutputSetting, mockOutputSetting2] }),
+            getAllConnectors: jest.fn().mockResolvedValue({ data: [] }),
+            getConnectorById: jest.fn().mockResolvedValue({}),
+            getConnectorByIdAs: jest.fn().mockResolvedValue({}),
+            getOutputSettingsById: jest.fn().mockResolvedValue({}),
+            getTaskStatus: jest.fn().mockResolvedValue({}),
+            generateOutput: jest.fn().mockResolvedValue({}),
+        })),
+    },
+}));
+
+const environmentBaseURL = 'https://test-api.test.com/grafx/api/v1/environment/test-api';
+const projectID = 'projectId';
+const token = 'auth-token';
+
+const config = {
+    selector: 'sui-root',
+    projectUploadUrl: `${environmentBaseURL}/projects/${projectID}`,
+    projectId: projectID,
+    graFxStudioEnvironmentApiBaseUrl: environmentBaseURL,
+    authToken: token,
+    projectName: '',
+    userInterfaceID: mockUserInterface.id,
+    onFetchUserInterfaceDetails: () => Promise.resolve(mockUserInterface),
+};
+
+const textVariable = variables.find((item) => item.id === 'shortVariable 1') as ShortTextVariable;
+
+const pushVariables = async (vars: unknown[]) => {
+    await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (window.StudioUISDK as any).subscriber.onVariableListChanged(JSON.stringify(vars));
+    });
+};
+
+describe('StudioUI.validateVariables() public API', () => {
+    it('returns the failing required-but-empty variable and flags it red in the UI', async () => {
+        render(<div id="sui-root" />);
+        let instance: StudioUI | null = null;
+        act(() => {
+            instance = StudioUI.studioUILoaderConfig(config);
+        });
+
+        await pushVariables([{ ...textVariable, value: '', isRequired: true, isVisible: true }]);
+
+        await waitFor(() => {
+            expect(screen.queryByText('This field is required')).not.toBeInTheDocument();
+        });
+
+        let result: Array<{ id: string }> = [];
+        await act(async () => {
+            result = await instance!.validateVariables();
+        });
+
+        expect(result).toEqual([{ id: textVariable.id }]);
+        await waitFor(() => {
+            expect(screen.getByText('This field is required')).toBeInTheDocument();
+        });
+    });
+
+    it('is idempotent: re-running after the value is filled returns [] and un-flags the field', async () => {
+        render(<div id="sui-root" />);
+        let instance: StudioUI | null = null;
+        act(() => {
+            instance = StudioUI.studioUILoaderConfig(config);
+        });
+
+        await pushVariables([{ ...textVariable, value: '', isRequired: true, isVisible: true }]);
+
+        await act(async () => {
+            await instance!.validateVariables();
+        });
+        await waitFor(() => {
+            expect(screen.getByText('This field is required')).toBeInTheDocument();
+        });
+
+        // value is filled in, then we re-validate
+        await pushVariables([{ ...textVariable, value: 'now filled', isRequired: true, isVisible: true }]);
+
+        let result: Array<{ id: string }> = [{ id: 'placeholder' }];
+        await act(async () => {
+            result = await instance!.validateVariables();
+        });
+
+        expect(result).toEqual([]);
+        await waitFor(() => {
+            expect(screen.queryByText('This field is required')).not.toBeInTheDocument();
+        });
+    });
+
+    it('ignores hidden variables (isVisible === false)', async () => {
+        render(<div id="sui-root" />);
+        let instance: StudioUI | null = null;
+        act(() => {
+            instance = StudioUI.studioUILoaderConfig(config);
+        });
+
+        await pushVariables([{ ...textVariable, value: '', isRequired: true, isVisible: false }]);
+
+        let result: Array<{ id: string }> = [{ id: 'placeholder' }];
+        await act(async () => {
+            result = await instance!.validateVariables();
+        });
+
+        expect(result).toEqual([]);
+    });
+
+    it('is a safe no-op (returns []) when called after destroy()', async () => {
+        render(<div id="sui-root" />);
+        let instance: StudioUI | null = null;
+        act(() => {
+            instance = StudioUI.studioUILoaderConfig(config);
+        });
+
+        await pushVariables([{ ...textVariable, value: '', isRequired: true, isVisible: true }]);
+
+        act(() => {
+            instance!.destroy();
+        });
+
+        const result = await instance!.validateVariables();
+        expect(result).toEqual([]);
+    });
+
+    it('returns [] when called before any variables exist in the store', async () => {
+        render(<div id="sui-root" />);
+        let instance: StudioUI | null = null;
+        act(() => {
+            instance = StudioUI.studioUILoaderConfig(config);
+        });
+
+        const result = await instance!.validateVariables();
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION

Implements [MAIN-2619](https://chilipublishintranet.atlassian.net/browse/MAIN-2619).

> **This is a suggested implementation to accompany the feature request, not a finished proposal.**
> The FR is the real artifact — this PR exists to give whoever picks it up a head start. Take it, merge it, change it, rewrite it, throw it out. If even one of the design notes below saves you a meeting, it's done its job. I won't be offended if the merged version looks nothing like this.

## What the feature gives integrators

A host application embedding Studio UI gets a single method it can call from its own workflow button (Save, Submit, Next step, Add to cart, Send to print) to ask Studio UI:


Concretely, an integrator builds their own button outside Studio UI and, on click:

```js
const ui = window.StudioUI.studioUILoaderConfig({ /* ...config... */ });

async function onHostSubmit() {
    const invalid = await ui.validateVariables();
    if (invalid.length) {
        // The required-but-empty fields are now highlighted red in the Studio UI form.
        // invalid === [{ id: 'var-a' }, { id: 'var-c' }]
        return; // block the host workflow; the user can see what to fix
    }
    await myHostSubmit();
}
```

The integrator does **not** re-implement Studio UI's validation rules and so cannot drift from the built-in Download button's behaviour on the next release.

## Shape this PR proposes

One additive, imperative method on the public `StudioUI` instance that `studioUILoaderConfig` / `defaultStudioUILoaderConfig` already return:

```ts
class StudioUI {
    // existing
    static studioUILoaderConfig(config): StudioUI | null;
    static defaultStudioUILoaderConfig(config): StudioUI;
    destroy(): void;

    // NEW
    /** Validate all visible variables, flag required-but-empty fields red, and return the failures. */
    validateVariables(): Promise<Array<{ id: string }>>;
}
```

Purely additive: no existing behaviour changes, no public signatures change. Both the IIFE consumer (`window.StudioUI` instance) and the ES-module consumer (`import StudioUI from 'studio-ui'`) get it automatically, since `src/index.ts` and `src/es-index.ts` re-export the same `StudioUI` default.

## How this implementation works

The implementation reuses the **exact same `validateVariableList()` thunk the Download button dispatches** — which is the whole point.

1. **Retain the store on the loader instance** (`src/deprecated-loaders.tsx`). The base loader created the Redux `store` as a local `const` and threw it away. We now keep a typed reference (`protected store`) so the public API can `dispatch`/`getState`, and release it in `destroy()`. `ReturnType<typeof setupStore>` gives the correctly typed store; its `dispatch` is the same `AppDispatch` the app uses.
2. **Add `validateVariables()`** (`src/main.tsx`). It dispatches `validateVariableList()` (which marks every visible required-but-empty field with an `errorMsg`, turning it red), unwraps the `{ validation }` result, and maps every entry with a non-empty `errorMsg` to `{ id }`.

```ts
public async validateVariables(): Promise<Array<{ id: string }>> {
    if (!this.store) return [];
    const { validation } = await this.store.dispatch(validateVariableList()).unwrap();
    return Object.entries(validation)
        .filter(([, v]) => Boolean(v.errorMsg))
        .map(([id]) => ({ id }));
}
```

### Behavioural contract

- **Idempotent.** Re-running it after values change re-evaluates every visible field, so fields that have since been filled are un-flagged.
- **Visible-only.** Hidden variables (`isVisible === false`) are ignored.
- **Readiness.** Meaningful only after the project has loaded (after the `onProjectLoaded` config callback fires). Called earlier — before any variables exist — or after `destroy()`, it is a safe no-op returning `[]`.

## Design notes (for whoever picks this up)

These are decisions this PR made that the merged version might want to reconsider. Each is independent — disagreeing with any of them doesn't blow up the rest.

### Why the return shape is `Array<{ id: string }>` and not `string[]`

Forward compatibility. Today there is exactly one failure mode (`isRequired` + empty value), so there is no `reason` field — modelling a taxonomy with a single member would be premature. But wrapping the id in an object means that if validation ever grows to cover pattern/format/range (or the image-load gap below), the natural shape becomes `{ id, reason }`:

- `Array<{ id }>` → `Array<{ id, reason }>` is **additive** — adding a field breaks no existing consumer.
- `string[]` → `Array<{ id, reason }>` would be a **breaking** change to every caller.

A bare string is a positional commitment we can't grow; a one-field object keeps the door open at zero cost today. If `reason` is eventually added, a typed string-literal union (`'required' | 'pattern' | …`) is preferable to free text, so hosts can `switch` on it and we never leak internal UI copy. If a field can fail for multiple reasons at once, `reasons: string[]` from the outset is safer than later renaming `reason` → `reasons`.

Keep in mind Publisher has the ability to validate not just on required by also on an action. It is not unreasonable that one day Studio will implement the same - imagine a validation for phone numbers.

If we introduce [MAIN-2615](https://chilipublishintranet.atlassian.net/browse/MAIN-2615), you could imagine a reason being `'image-failed' | 'required'`.

### Why only `id` (no `name` / `label` / `value`)

The host already has the `id`; everything else is reachable through the engine SDK (`window.StudioUISDK.variable.*`). Returning only `id` keeps the contract small and avoids coupling the public API to translation concerns — `label` may be a translation key resolved via `variableTranslations`, so exposing a "name" that sometimes matches the visible text and sometimes is a raw key would be a misleading contract. The SDK is the source of truth for display details.

### Things considered and deliberately left out

- **No `clearVariableValidation()` counterpart.** The sweep is idempotent (re-running un-flags now-valid fields), and the interactive blur path already clears a field once the user fixes it. The only thing a `clear` method would uniquely add is hiding the error on a field that is still invalid — a footgun, not a feature.
- **No `reason` field on the result (yet).** See "return shape" above — the object wrapper exists so this can be added later non-breakingly.
- **No readiness getter on the instance.** The host gates on the existing `onProjectLoaded` callback. Internal readiness (`isDocumentLoaded`) lives in React/`AppProvider` context, not in the Redux store, so a store-based method can't distinguish "not ready" from "all valid" anyway — both surface as `[]`. Lifting readiness into the store is a larger change worth its own discussion.
- **Failing DataSource variables are reported but not visually flagged.** A failing DataSource var is included in the returned array (so the host's gate is correct), but the DataSource inputs don't forward `required`/`validationError` to their control, so it won't *look* flagged. Documented limitation; forwarding those props to the inputs would be a small follow-up, and something that should be done to ensure same behavior. However, it is outside the scope of this PR.
- **No per-field public `validateVariable(id)`** — scope is the whole-list "check before submit" sweep.
- **No auto-validation on load, no scroll-to / focus-first-invalid.** Scope purposely small. Validation stays interaction-/submit-triggered by design. Focus-first-invalid is a plausible follow-up built on the returned ids + existing `onVariableFocus` plumbing.

## Files changed

| File | Change |
|---|---|
| `src/deprecated-loaders.tsx` | Retain `store` on the instance; release on `destroy()`. |
| `src/main.tsx` | Add `validateVariables()` with JSDoc; map thunk result → `Array<{ id }>`. |
| `src/tests/integration/ValidateVariables.test.tsx` | Loader + mapping + integration coverage. |
| `documentation/advanced-integration.md` | Document the new public method. |

## Tests

`src/tests/integration/ValidateVariables.test.tsx` mirrors `RequiredVariable.test.tsx` and covers:

- required + empty visible variable → returned array contains its `{ id }` **and** the field shows `This field is required`;
- value filled → `validateVariables()` returns `[]` and the error text is gone (idempotent un-flagging);
- hidden required-empty variable is ignored (not in the array);
- called after `destroy()` → returns `[]`, no throw;
- called before any variables exist → returns `[]`.

> The suite was **not** run locally — this checkout's private package registry (`@chili-publish` on GitHub Packages, plus FontAwesome) requires auth tokens that aren't available in this environment, so `npm install` fails here.

---

# Important caveat for anyone using this as a pre-submit gate: `required` is not trustworthy for image variables
This is **not** introduced by this PR — it's a pre-existing gap that `validateVariables()` inherits from `validateVariableValue`, and it's tracked in [MAIN-2615](https://chilipublishintranet.atlassian.net/browse/MAIN-2619). Calling it out here because anyone planning to use this method as a pre-submit gate needs to know. My hope is that once MAIN-2615 is implemented, `validateVariables()` will inherit the implementation — i.e. image variables with a broken/undownloadable asset and required will show up in the returned array alongside required-but-empty fields, with no further changes needed on the UI side.
**`validateVariables()` answers "is a required value present?" — not "did the asset actually load / render?"** For image variables those are very different promises:
- `validateVariableValue` treats an image as valid the instant `value.assetId` (or `value.resolved`) is truthy. `assetId` is just the *requested* id; it stays set even when the asset is missing, unauthorized, renamed, or undownloadable.
- A template can pass all required checks and still go to output with broken or missing images. For a production/printing product, a "required" gate that lets unusable images through is arguably worse than no gate — it gives a green light operators trust.

**What this means for integrators today:** use `validateVariables()` to gate on required-empty fields (its real, reliable job). If you also need "did the image actually load", probe the engine SDK directly per asset (`window.StudioUISDK.mediaConnector.detail(connectorId, assetId)` throws on 404/401), as `usePreviewImage.ts` does internally. This limitation is documented in `advanced-integration.md`.

[MAIN-2619]: https://chilipublishintranet.atlassian.net/browse/MAIN-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAIN-2615]: https://chilipublishintranet.atlassian.net/browse/MAIN-2615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ