### PR TITLE
[Fix][WRS-3078] Handle "stageFiles" unauthorized call properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.28.6",
         "@chili-publish/environment-client-api": "0.31.9",
         "@chili-publish/grafx-shared-components": "0.120.7",
-        "@chili-publish/studio-sdk": "https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz",
+        "@chili-publish/studio-sdk": "1.44.0-alpha.11",
         "@fortawesome/fontawesome-svg-core": "^6.7.1",
         "@fortawesome/pro-light-svg-icons": "^6.7.1",
         "@fortawesome/pro-regular-svg-icons": "^6.7.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.28.6",
         "@chili-publish/environment-client-api": "0.31.9",
         "@chili-publish/grafx-shared-components": "0.120.7",
-        "@chili-publish/studio-sdk": "1.44.0-alpha.7",
+        "@chili-publish/studio-sdk": "https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz",
         "@fortawesome/fontawesome-svg-core": "^6.7.1",
         "@fortawesome/pro-light-svg-icons": "^6.7.1",
         "@fortawesome/pro-regular-svg-icons": "^6.7.1",

--- a/src/components/variablesComponents/dataSourceVariable/useDataSourceVariable.ts
+++ b/src/components/variablesComponents/dataSourceVariable/useDataSourceVariable.ts
@@ -6,8 +6,9 @@ import {
     DataSourceVariableSource,
     DataSourceVariableSourceType,
     InjectedDataSourceVariableSource,
+    DataItem,
+    DataSourceVariableDataModel,
 } from '@chili-publish/studio-sdk';
-import { DataItem, DataSourceVariableDataModel } from '@chili-publish/studio-sdk/connector-types/src';
 import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getPage, getPageItemById } from 'src/components/shared/DataSource/dataSource.util';

--- a/src/components/variablesComponents/imageVariable/useUploadAsset.ts
+++ b/src/components/variablesComponents/imageVariable/useUploadAsset.ts
@@ -1,25 +1,31 @@
 import {
+    FilePointer,
     ImageVariable,
     Media,
+    SDKUnauthorizedError,
     UploadAssetValidationError,
     UploadAssetValidationErrorType,
     UploadValidationConfiguration,
 } from '@chili-publish/studio-sdk';
 import { useCallback, useState } from 'react';
+import { TokenService } from 'src/services/TokenService';
 
 export const uploadFileMimeTypes = ['image/jpg', 'image/jpeg', 'image/png', 'image/tiff'];
 
-function getUploadError(error: UploadAssetValidationError, imageVariable: ImageVariable) {
+function getUploadError(
+    error: UploadAssetValidationError,
+    { uploadMinWidth, uploadMinHeight }: Pick<ImageVariable, 'uploadMinWidth' | 'uploadMinHeight'>,
+) {
     switch (error.type) {
         case UploadAssetValidationErrorType.minDimension:
-            if (imageVariable.uploadMinWidth && imageVariable.uploadMinHeight) {
-                return `The image needs to be at least ${imageVariable.uploadMinWidth}x${imageVariable.uploadMinHeight} px.`;
+            if (uploadMinWidth && uploadMinHeight) {
+                return `The image needs to be at least ${uploadMinWidth}x${uploadMinHeight} px.`;
             }
-            if (imageVariable.uploadMinWidth) {
-                return `The image needs to be at least ${imageVariable.uploadMinWidth} px wide.`;
+            if (uploadMinWidth) {
+                return `The image needs to be at least ${uploadMinWidth} px wide.`;
             }
-            if (imageVariable.uploadMinHeight) {
-                return `The image needs to be at least ${imageVariable.uploadMinHeight} px high.`;
+            if (uploadMinHeight) {
+                return `The image needs to be at least ${uploadMinHeight} px high.`;
             }
             return 'Something went wrong.';
         default:
@@ -31,24 +37,65 @@ export const useUploadAsset = (remoteConnectorId: string | undefined, imageVaria
     const [pending, setPending] = useState(false);
     const [uploadError, setUploadError] = useState<string>();
 
+    const stageFiles = useCallback(
+        async (
+            files: File[],
+            validationConfiguration: Omit<UploadValidationConfiguration, 'mimeTypes'>,
+        ): Promise<FilePointer[] | null> => {
+            const executor = async () => {
+                if (!remoteConnectorId) {
+                    return null;
+                }
+                try {
+                    return await window.StudioUISDK.utils.stageFiles(files, remoteConnectorId, {
+                        mimeTypes: uploadFileMimeTypes,
+                        ...validationConfiguration,
+                    });
+                } catch (error) {
+                    if (error instanceof UploadAssetValidationError) {
+                        setUploadError(
+                            getUploadError(error, {
+                                uploadMinWidth: imageVariable.uploadMinWidth,
+                                uploadMinHeight: imageVariable.uploadMinHeight,
+                            }),
+                        );
+                        return null;
+                    }
+                    throw error;
+                }
+            };
+            try {
+                return await executor();
+            } catch (error) {
+                if (error instanceof SDKUnauthorizedError) {
+                    const tokenService = TokenService.getInstance();
+                    await tokenService.refreshToken();
+                    return executor();
+                }
+                throw error;
+            }
+        },
+        [remoteConnectorId, imageVariable.uploadMinWidth, imageVariable.uploadMinHeight],
+    );
+
     const upload = useCallback(
         async (
             files: File[],
             validationConfiguration: Omit<UploadValidationConfiguration, 'mimeTypes'>,
         ): Promise<Media | null> => {
-            if (!remoteConnectorId || !imageVariable.value?.connectorId) {
+            if (!imageVariable.value?.connectorId) {
                 return null;
             }
             try {
                 setPending(true);
                 setUploadError(undefined);
                 // 1. Stage selected files
-                const filePointers = await window.StudioUISDK.utils.stageFiles(files, remoteConnectorId, {
-                    mimeTypes: uploadFileMimeTypes,
-                    ...validationConfiguration,
-                });
+                const filePointers = await stageFiles(files, validationConfiguration);
+                if (!filePointers) {
+                    return null;
+                }
 
-                // // 2. Upload files through the connector
+                // 2. Upload files through the connector
                 const { parsedData } = await window.StudioUISDK.mediaConnector.upload(
                     imageVariable.value.connectorId,
                     filePointers,
@@ -56,17 +103,13 @@ export const useUploadAsset = (remoteConnectorId: string | undefined, imageVaria
 
                 return parsedData?.[0] ?? null;
             } catch (error) {
-                if (error instanceof UploadAssetValidationError) {
-                    setUploadError(getUploadError(error, imageVariable));
-                } else {
-                    setUploadError('Something went wrong.');
-                }
-                return null;
+                setUploadError('Something went wrong.');
             } finally {
                 setPending(false);
             }
+            return null;
         },
-        [remoteConnectorId, imageVariable],
+        [imageVariable, stageFiles],
     );
 
     const resetUploadError = useCallback(() => {

--- a/src/core/hooks/useEditorAuthExpired.ts
+++ b/src/core/hooks/useEditorAuthExpired.ts
@@ -33,7 +33,8 @@ export const useEditorAuthExpired = (
     const handleAuthExpired = async (request: AuthRefreshRequest) => {
         try {
             if (request.type === AuthRefreshTypeEnum.grafxToken) {
-                const newToken = await TokenService.getInstance().refreshToken();
+                // Since it runs within Engine refresh context, we don't need to update the editor token via configuration
+                const newToken = await TokenService.getInstance().refreshToken(false);
                 return new GrafxTokenAuthCredentials(newToken);
             }
 

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -47,8 +47,9 @@ export class TokenService {
 
     /**
      * Refresh the authentication token
+     * @param updateEditorToken - Whether to update the editor token. When we refresh token within Engine context, we shouldn't update its configuration
      */
-    async refreshToken(): Promise<string> {
+    async refreshToken(updateEditorToken: boolean = true): Promise<string> {
         if (!this.refreshTokenAction) {
             throw new Error('The authentication token has expired, and a method to obtain a new one is not provided.');
         }
@@ -60,7 +61,9 @@ export class TokenService {
 
         // Update the current token
         this.currentToken = result;
-        await this.updateEditorToken();
+        if (updateEditorToken) {
+            await this.updateEditorToken();
+        }
         return result;
     }
 

--- a/src/tests/components/variablesComponents/imageVariable/useUploadAsset.test.ts
+++ b/src/tests/components/variablesComponents/imageVariable/useUploadAsset.test.ts
@@ -1,0 +1,232 @@
+import EditorSDK, {
+    ImageVariable,
+    SDKUnauthorizedError,
+    UploadAssetValidationError,
+    UploadAssetValidationErrorType,
+} from '@chili-publish/studio-sdk';
+import { act, waitFor } from '@testing-library/react';
+
+// Real SDK error classes are required for instanceof checks inside the hook.
+jest.unmock('@chili-publish/studio-sdk');
+import { mock } from 'jest-mock-extended';
+import { renderHookWithProviders } from '@tests/mocks/Provider';
+import { TokenService } from 'src/services/TokenService';
+import {
+    uploadFileMimeTypes,
+    useUploadAsset,
+} from '../../../../components/variablesComponents/imageVariable/useUploadAsset';
+import { variables as mockVariables } from '../../../mocks/mockVariables';
+
+const mockSDK = mock<EditorSDK>();
+
+describe('useUploadAsset', () => {
+    const remoteConnectorId = 'remote-connector-1';
+    const baseImageVariable = mockVariables[0] as ImageVariable;
+    const testFile = new File(['file'], 'test.png', { type: 'image/png' });
+    const validationConfiguration = { minWidthPixels: 100, minHeightPixels: 200 };
+    const filePointers = [{ id: 'fp-1', name: 'test.png' }];
+    const uploadedMedia = { id: 'media-123', name: 'test.png' };
+
+    beforeEach(() => {
+        window.StudioUISDK = mockSDK;
+        mockSDK.utils.stageFiles = jest.fn().mockResolvedValue(filePointers);
+        mockSDK.mediaConnector.upload = jest.fn().mockResolvedValue({ parsedData: [uploadedMedia] });
+
+        (TokenService.getInstance as jest.Mock).mockReturnValue({
+            refreshToken: jest.fn().mockResolvedValue('new-token'),
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('stages files and uploads through the media connector on success', async () => {
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, baseImageVariable));
+
+        let uploadResult: unknown;
+        await act(async () => {
+            uploadResult = await result.current.upload([testFile], validationConfiguration);
+        });
+
+        expect(mockSDK.utils.stageFiles).toHaveBeenCalledWith([testFile], remoteConnectorId, {
+            mimeTypes: uploadFileMimeTypes,
+            ...validationConfiguration,
+        });
+        expect(mockSDK.mediaConnector.upload).toHaveBeenCalledWith(baseImageVariable.value!.connectorId, filePointers);
+        expect(uploadResult).toEqual(uploadedMedia);
+        expect(result.current.uploadError).toBeUndefined();
+        expect(result.current.pending).toBe(false);
+    });
+
+    it.each([
+        {
+            uploadMinWidth: 800,
+            uploadMinHeight: 600,
+            expectedMessage: 'The image needs to be at least 800x600 px.',
+        },
+        {
+            uploadMinWidth: 800,
+            uploadMinHeight: undefined,
+            expectedMessage: 'The image needs to be at least 800 px wide.',
+        },
+        {
+            uploadMinWidth: undefined,
+            uploadMinHeight: 600,
+            expectedMessage: 'The image needs to be at least 600 px high.',
+        },
+        {
+            uploadMinWidth: undefined,
+            uploadMinHeight: undefined,
+            expectedMessage: 'Something went wrong.',
+        },
+    ])(
+        'maps min dimension validation errors ($expectedMessage)',
+        async ({ uploadMinWidth, uploadMinHeight, expectedMessage }) => {
+            (mockSDK.utils.stageFiles as jest.Mock).mockRejectedValue(
+                new UploadAssetValidationError('File is too small', UploadAssetValidationErrorType.minDimension),
+            );
+
+            const imageVariable = {
+                ...baseImageVariable,
+                uploadMinWidth,
+                uploadMinHeight,
+            };
+
+            const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, imageVariable));
+
+            await act(async () => {
+                await result.current.upload([testFile], validationConfiguration);
+            });
+
+            expect(result.current.uploadError).toBe(expectedMessage);
+        },
+    );
+
+    it('refreshes the token and retries staging when unauthorized', async () => {
+        const refreshToken = jest.fn().mockResolvedValue('new-token');
+        (TokenService.getInstance as jest.Mock).mockReturnValue({ refreshToken });
+
+        (mockSDK.utils.stageFiles as jest.Mock)
+            .mockRejectedValueOnce(new SDKUnauthorizedError('Unauthorized'))
+            .mockResolvedValueOnce(filePointers);
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, baseImageVariable));
+
+        let uploadResult: unknown;
+        await act(async () => {
+            uploadResult = await result.current.upload([testFile], validationConfiguration);
+        });
+
+        expect(refreshToken).toHaveBeenCalledTimes(1);
+        expect(mockSDK.utils.stageFiles).toHaveBeenCalledTimes(2);
+        expect(mockSDK.mediaConnector.upload).toHaveBeenCalledWith(baseImageVariable.value!.connectorId, filePointers);
+        expect(uploadResult).toEqual(uploadedMedia);
+    });
+
+    it('sets a generic upload error when media upload fails', async () => {
+        (mockSDK.mediaConnector.upload as jest.Mock).mockRejectedValue(new Error('Upload failed'));
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, baseImageVariable));
+
+        let uploadResult: unknown;
+        await act(async () => {
+            uploadResult = await result.current.upload([testFile], validationConfiguration);
+        });
+
+        expect(uploadResult).toBeNull();
+        expect(result.current.uploadError).toBe('Something went wrong.');
+        expect(result.current.pending).toBe(false);
+    });
+
+    it('sets a generic upload error when staging throws a non-validation error', async () => {
+        (mockSDK.utils.stageFiles as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, baseImageVariable));
+
+        let uploadResult: unknown;
+        await act(async () => {
+            uploadResult = await result.current.upload([testFile], validationConfiguration);
+        });
+
+        expect(uploadResult).toBeNull();
+        expect(result.current.uploadError).toBe('Something went wrong.');
+    });
+
+    it('tracks pending state during upload', async () => {
+        let resolveStageFiles: (value: typeof filePointers) => void = () => undefined;
+        const stageFilesPromise = new Promise<typeof filePointers>((resolve) => {
+            resolveStageFiles = resolve;
+        });
+        (mockSDK.utils.stageFiles as jest.Mock).mockReturnValue(stageFilesPromise);
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, baseImageVariable));
+
+        let uploadPromise: Promise<unknown>;
+        act(() => {
+            uploadPromise = result.current.upload([testFile], validationConfiguration);
+        });
+
+        await waitFor(() => {
+            expect(result.current.pending).toBe(true);
+        });
+
+        await act(async () => {
+            resolveStageFiles(filePointers);
+            await uploadPromise;
+        });
+
+        expect(result.current.pending).toBe(false);
+    });
+
+    it('clears upload error at the start of a new upload', async () => {
+        (mockSDK.utils.stageFiles as jest.Mock)
+            .mockRejectedValueOnce(
+                new UploadAssetValidationError('File is too small', UploadAssetValidationErrorType.minDimension),
+            )
+            .mockResolvedValueOnce(filePointers);
+
+        const imageVariable = {
+            ...baseImageVariable,
+            uploadMinWidth: 800,
+        };
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, imageVariable));
+
+        await act(async () => {
+            await result.current.upload([testFile], validationConfiguration);
+        });
+        expect(result.current.uploadError).toBe('The image needs to be at least 800 px wide.');
+
+        await act(async () => {
+            await result.current.upload([testFile], validationConfiguration);
+        });
+
+        expect(result.current.uploadError).toBeUndefined();
+        expect(result.current.pending).toBe(false);
+    });
+
+    it('clears upload error via resetUploadError', async () => {
+        (mockSDK.utils.stageFiles as jest.Mock).mockRejectedValue(
+            new UploadAssetValidationError('File is too small', UploadAssetValidationErrorType.minDimension),
+        );
+
+        const imageVariable = {
+            ...baseImageVariable,
+            uploadMinWidth: 800,
+        };
+
+        const { result } = renderHookWithProviders(() => useUploadAsset(remoteConnectorId, imageVariable));
+
+        await act(async () => {
+            await result.current.upload([testFile], validationConfiguration);
+        });
+        expect(result.current.uploadError).toBeDefined();
+
+        act(() => {
+            result.current.resetUploadError();
+        });
+
+        expect(result.current.uploadError).toBeUndefined();
+    });
+});

--- a/src/tests/core/hooks/useEditorAuthExpired.test.ts
+++ b/src/tests/core/hooks/useEditorAuthExpired.test.ts
@@ -4,6 +4,7 @@ import {
     AuthRefreshTypeEnum,
     ConnectorType,
     ConnectorSupportedAuth,
+    GrafxTokenAuthCredentials,
 } from '@chili-publish/studio-sdk';
 import { useEditorAuthExpired } from 'src/core/hooks/useEditorAuthExpired';
 import { TokenService } from 'src/services/TokenService';
@@ -203,6 +204,34 @@ describe('useEditorAuthExpired', () => {
             'remote-123',
         );
         expect(authResult).toEqual(errorResult);
+    });
+
+    it('should refresh grafx token without updating editor configuration', async () => {
+        const mockRefreshToken = jest.fn().mockResolvedValue('refreshed-token');
+        (TokenService.getInstance as jest.Mock).mockReturnValue({
+            refreshToken: mockRefreshToken,
+        });
+
+        const { result } = renderHookWithProviders(() =>
+            useEditorAuthExpired(mockOnConnectorAuthenticationRequested, mockCreateProcessFn),
+        );
+        const handleAuthExpired = result.current;
+
+        const request: AuthRefreshRequest = {
+            type: AuthRefreshTypeEnum.grafxToken,
+            connectorId: '',
+            remoteConnectorId: '',
+            headerValue: '',
+            connectorDefinition: {
+                ...baseConnectorDefinition,
+                name: '',
+            },
+        };
+
+        const authResult = await handleAuthExpired(request);
+
+        expect(mockRefreshToken).toHaveBeenCalledWith(false);
+        expect(authResult).toEqual(new GrafxTokenAuthCredentials('refreshed-token'));
     });
 
     it('should handle errors gracefully', async () => {

--- a/src/tests/services/TokenService.test.ts
+++ b/src/tests/services/TokenService.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { WellKnownConfigurationKeys } from '@chili-publish/studio-sdk';
+import { TokenService } from '../../services/TokenService';
+
+jest.unmock('../../services/TokenService');
+
+describe('TokenService', () => {
+    const initialToken = 'initial-token';
+    const refreshedToken = 'refreshed-token';
+
+    beforeEach(() => {
+        (TokenService as any).instance = null;
+        window.StudioUISDK.configuration.setValue = jest.fn().mockResolvedValue(undefined);
+    });
+
+    describe('getInstance', () => {
+        it('throws when not initialized', () => {
+            expect(() => TokenService.getInstance()).toThrow(
+                'TokenService not initialized. Call TokenService.initialize() first.',
+            );
+        });
+
+        it('returns the singleton after initialize', () => {
+            TokenService.initialize(() => initialToken);
+
+            const instance = TokenService.getInstance();
+
+            expect(instance).toBe(TokenService.getInstance());
+            expect(instance.getToken()).toBe(initialToken);
+        });
+    });
+
+    describe('getToken', () => {
+        it('returns the token from getTokenAction at initialization', () => {
+            TokenService.initialize(() => initialToken);
+
+            expect(TokenService.getInstance().getToken()).toBe(initialToken);
+        });
+    });
+
+    describe('refreshToken', () => {
+        it('throws when refreshTokenAction is not provided', async () => {
+            TokenService.initialize(() => initialToken);
+
+            await expect(TokenService.getInstance().refreshToken()).rejects.toThrow(
+                'The authentication token has expired, and a method to obtain a new one is not provided.',
+            );
+        });
+
+        it('throws when refreshTokenAction returns an Error', async () => {
+            const refreshError = new Error('refresh failed');
+            TokenService.initialize(
+                () => initialToken,
+                async () => refreshError,
+            );
+
+            await expect(TokenService.getInstance().refreshToken()).rejects.toThrow(refreshError);
+        });
+
+        it('updates the token and editor configuration by default', async () => {
+            const refreshTokenAction = jest.fn().mockResolvedValue(refreshedToken);
+            TokenService.initialize(() => initialToken, refreshTokenAction);
+
+            const result = await TokenService.getInstance().refreshToken();
+
+            expect(refreshTokenAction).toHaveBeenCalled();
+            expect(result).toBe(refreshedToken);
+            expect(TokenService.getInstance().getToken()).toBe(refreshedToken);
+            expect(window.StudioUISDK.configuration.setValue).toHaveBeenCalledWith(
+                WellKnownConfigurationKeys.GraFxStudioAuthToken,
+                refreshedToken,
+            );
+        });
+
+        it('updates the token without updating editor configuration when updateEditorToken is false', async () => {
+            const refreshTokenAction = jest.fn().mockResolvedValue(refreshedToken);
+            TokenService.initialize(() => initialToken, refreshTokenAction);
+
+            const result = await TokenService.getInstance().refreshToken(false);
+
+            expect(result).toBe(refreshedToken);
+            expect(TokenService.getInstance().getToken()).toBe(refreshedToken);
+            expect(window.StudioUISDK.configuration.setValue).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('updateEditorToken', () => {
+        it('sets the current token in the editor SDK configuration', async () => {
+            TokenService.initialize(() => initialToken);
+
+            await TokenService.getInstance().updateEditorToken();
+
+            expect(window.StudioUISDK.configuration.setValue).toHaveBeenCalledWith(
+                WellKnownConfigurationKeys.GraFxStudioAuthToken,
+                initialToken,
+            );
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,10 +1325,9 @@
   resolved "https://npm.pkg.github.com/download/@chili-publish/grafx-shared-components/0.120.7/8d9f79f88993d266abbd790b02188d34c285986f#8d9f79f88993d266abbd790b02188d34c285986f"
   integrity sha512-YjYaLn5bNW2KU079yejFkYowbLnu1jv4HD0xJ13fBnnvrsax4NbJP7OGVr7LfdpAQMBPU9q9nMfVxgkm2IkIQA==
 
-"@chili-publish/studio-sdk@1.44.0-alpha.7":
-  version "1.44.0-alpha.7"
-  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.44.0-alpha.7/d2338edf335f291a1fc245442f91103762402f6f#d2338edf335f291a1fc245442f91103762402f6f"
-  integrity sha512-cJOIk4/PpR82WJrcQhNN77gDaPNLKDim/vnuhmECMBUHzQZjHUxFeSrxwAmtgxXheLl1wQLXgsJoxj7uEJJWxg==
+"@chili-publish/studio-sdk@https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz":
+  version "1.44.0-alpha.10"
+  resolved "https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz#a82ef02be8d0226a70c9ec1c1a70e84779625222"
   dependencies:
     penpal "6.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,9 +1325,10 @@
   resolved "https://npm.pkg.github.com/download/@chili-publish/grafx-shared-components/0.120.7/8d9f79f88993d266abbd790b02188d34c285986f#8d9f79f88993d266abbd790b02188d34c285986f"
   integrity sha512-YjYaLn5bNW2KU079yejFkYowbLnu1jv4HD0xJ13fBnnvrsax4NbJP7OGVr7LfdpAQMBPU9q9nMfVxgkm2IkIQA==
 
-"@chili-publish/studio-sdk@https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz":
-  version "1.44.0-alpha.10"
-  resolved "https://stgrafxstudiodevpublic.blob.core.windows.net/sdk/dev-packages/789/studio-sdk.tgz#a82ef02be8d0226a70c9ec1c1a70e84779625222"
+"@chili-publish/studio-sdk@1.44.0-alpha.11":
+  version "1.44.0-alpha.11"
+  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.44.0-alpha.11/18107589a5810676bee7e671d759442a3da3f87a#18107589a5810676bee7e671d759442a3da3f87a"
+  integrity sha512-Jnv33I+ldh7iRlXYdavhNeJEKQfD3d859Si/RkhKbukqfGtJT5cAWGRHZNhoIrH4UCRM1Z/hhEbp1++Ic9K70A==
   dependencies:
     penpal "6.1.0"
 


### PR DESCRIPTION
- Run refresh token logic if "stageFiles" received 401 for the first time
- [WRS-3079] Avoid setting of Editor token via configuration for Editor refresh token context

This PR

## Related tickets

- [WRS-3078](https://chilipublishintranet.atlassian.net/browse/WRS-3078)
- [WRS-3079](https://chilipublishintranet.atlassian.net/browse/WRS-3079)

## Screenshots


[WRS-3079]: https://chilipublishintranet.atlassian.net/browse/WRS-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WRS-3078]: https://chilipublishintranet.atlassian.net/browse/WRS-3078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WRS-3079]: https://chilipublishintranet.atlassian.net/browse/WRS-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ