### PR TITLE
[Fix] Use latest SDK with proper bundle code

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,4 @@
-const esModules = ['@chili-publish/studio-sdk/lib/src/next', '@chili-publish/environment-client-api'].join('|');
+const esModules = ['@chili-publish/environment-client-api'].join('|');
 
 module.exports = {
     roots: ['<rootDir>'],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.28.6",
         "@chili-publish/environment-client-api": "0.31.9",
         "@chili-publish/grafx-shared-components": "0.120.7",
-        "@chili-publish/studio-sdk": "1.44.0-alpha.11",
+        "@chili-publish/studio-sdk": "1.44.0-alpha.12",
         "@fortawesome/fontawesome-svg-core": "^6.7.1",
         "@fortawesome/pro-light-svg-icons": "^6.7.1",
         "@fortawesome/pro-regular-svg-icons": "^6.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,10 +1325,10 @@
   resolved "https://npm.pkg.github.com/download/@chili-publish/grafx-shared-components/0.120.7/8d9f79f88993d266abbd790b02188d34c285986f#8d9f79f88993d266abbd790b02188d34c285986f"
   integrity sha512-YjYaLn5bNW2KU079yejFkYowbLnu1jv4HD0xJ13fBnnvrsax4NbJP7OGVr7LfdpAQMBPU9q9nMfVxgkm2IkIQA==
 
-"@chili-publish/studio-sdk@1.44.0-alpha.11":
-  version "1.44.0-alpha.11"
-  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.44.0-alpha.11/18107589a5810676bee7e671d759442a3da3f87a#18107589a5810676bee7e671d759442a3da3f87a"
-  integrity sha512-Jnv33I+ldh7iRlXYdavhNeJEKQfD3d859Si/RkhKbukqfGtJT5cAWGRHZNhoIrH4UCRM1Z/hhEbp1++Ic9K70A==
+"@chili-publish/studio-sdk@1.44.0-alpha.12":
+  version "1.44.0-alpha.12"
+  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.44.0-alpha.12/5886dfed3b54dd9bb10a316c4e556e5a5a1d8c87#5886dfed3b54dd9bb10a316c4e556e5a5a1d8c87"
+  integrity sha512-uCVu4KT3TVPo9XOjZeC+YA195HFeqtFYeYMVUs1qk4tQ1gZv4EGlRXhMWvX90U3iKjBLeReiVvvxrZWKPMhcOA==
   dependencies:
     penpal "6.1.0"
 


### PR DESCRIPTION
Upgrade to lastes SDK version that supports both ES/CJS bundles to avoid tweaking from the integration source

This PR

## Related tickets

-   [WRS-NUMBER](https://chilipublishintranet.atlassian.net/browse/WRS-NUMBER)

## Screenshots
