### PR TITLE
[AIML-40] Fix memory leak of run mode

### DIFF
--- a/src/MainContent.tsx
+++ b/src/MainContent.tsx
@@ -48,6 +48,7 @@ import { setConfiguration } from './store/reducers/documentReducer';
 import { LoadDocumentError, Project, ProjectConfig } from './types/types';
 import { useDataRowExceptionHandler } from './hooks/useDataRowExceptionHandler';
 import { APP_WRAPPER_ID } from './utils/constants';
+import { teardownSdk } from './utils/sdkTeardown';
 import { useDirection } from './hooks/useDirection';
 import { setVariables } from './store/reducers/variableReducer';
 import { TokenService } from './services/TokenService';
@@ -360,11 +361,24 @@ const MainContent = ({ projectConfig }: MainContentProps) => {
         });
         // eslint-disable-next-line consistent-return
         return () => {
-            // Prevent loading multiple iframes
-            const iframeContainer = document.getElementsByTagName('iframe')[0];
-            iframeContainer?.remove();
             enableAutoSaveRef.current = false;
             onDocumentLoadedUnsubscribe();
+
+            // Shut the engine down and remove its iframe. Previously this removed
+            // `document.getElementsByTagName('iframe')[0]`, which is the first iframe on
+            // the page rather than this engine's, and it never closed the connection - so
+            // every unmount left a fully live engine behind.
+            teardownSdk(sdk, EDITOR_ID);
+
+            // These globals outlive the component, so they have to be released too or they
+            // pin the SDK - and through it the engine realm - for the lifetime of the page.
+            if (window.StudioUISDK === sdk) {
+                window.StudioUISDK = undefined as unknown as StudioSDK;
+            }
+            if (window.SDK === sdk) {
+                window.SDK = undefined as unknown as StudioSDK;
+            }
+            setSDKRef(undefined);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [eventSubscriber]);

--- a/src/deprecated-loaders.tsx
+++ b/src/deprecated-loaders.tsx
@@ -19,14 +19,33 @@ export default class StudioUILoader {
 
     protected store: ReturnType<typeof setupStore> | undefined;
 
-    constructor(selector: string, projectConfig: ProjectConfig, appConfig: AppConfig = {}) {
-        const container = document.getElementById(selector || 'sui-root');
+    private container: HTMLElement | null = null;
 
-        if (this.root) {
+    private selector: string;
+
+    /**
+     * Selectors that currently have a Studio UI mounted into them.
+     *
+     * This has to be tracked statically: the previous guard checked `this.root`, which is
+     * always undefined on a freshly constructed instance, so it could never fire. A second
+     * mount on the same container then silently created a second React root and a second
+     * engine, leaving the first one running for the lifetime of the page.
+     */
+    private static mountedSelectors = new Set<string>();
+
+    constructor(selector: string, projectConfig: ProjectConfig, appConfig: AppConfig = {}) {
+        const resolvedSelector = selector || 'sui-root';
+        const container = document.getElementById(resolvedSelector);
+
+        if (StudioUILoader.mountedSelectors.has(resolvedSelector)) {
             throw new Error(
                 'Studio UI component is already instantiated. Destroy first, if you wanna to mount a new one',
             );
         }
+
+        this.selector = resolvedSelector;
+        this.container = container;
+        StudioUILoader.mountedSelectors.add(resolvedSelector);
 
         this.store = setupStore({
             appConfig,
@@ -41,13 +60,30 @@ export default class StudioUILoader {
         );
     }
 
+    /**
+     * Unmounts Studio UI and releases the engine it loaded.
+     *
+     * Unmounting alone is not enough: the engine iframe is appended imperatively by the
+     * SDK, so anything left in the container after React is gone would keep the engine
+     * realm (Dart heap, CanvasKit and QuickJS WASM memory) alive. Safe to call twice.
+     */
     destroy() {
-        if (this.root) {
-            // eslint-disable-next-line no-console
-            console.warn('Destroying Studio UI component...');
-            this.root.unmount();
-            this.root = undefined;
-            this.store = undefined;
+        if (!this.root) {
+            return;
         }
+        // eslint-disable-next-line no-console
+        console.warn('Destroying Studio UI component...');
+
+        // Unmount first: MainContent's cleanup tears the SDK connection down and removes
+        // the engine iframe while it still knows which one belongs to this instance.
+        this.root.unmount();
+
+        // Anything the SDK appended outside of React's tree is dropped here.
+        this.container?.replaceChildren();
+
+        StudioUILoader.mountedSelectors.delete(this.selector);
+        this.root = undefined;
+        this.store = undefined;
+        this.container = null;
     }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -58,9 +58,29 @@ export default class StudioUI extends StudioUILoader {
      * @returns
      */
     private static fullStudioIntegrationConfig(selector: string, projectConfig: ProjectConfig, appConfig?: AppConfig) {
+        // Every mount creates its own engine, so the previous one has to be shut down here.
+        // This is the single funnel all loader entry points go through; without it a host
+        // that re-configures Studio UI (switching in and out of sandbox mode, for example)
+        // stacks a second live engine on top of the first and leaks around 190MB each time.
+        this.instance?.destroy();
+        this.instance = undefined;
+
         const instance = new StudioUI(selector, projectConfig, appConfig);
         this.instance = instance;
         return instance;
+    }
+
+    /**
+     * Unmounts this Studio UI instance and releases the engine it loaded.
+     *
+     * Hosts should call this when they remove Studio UI from the page - hiding its
+     * container is not enough, the engine keeps running behind it.
+     */
+    override destroy() {
+        super.destroy();
+        if (StudioUI.instance === this) {
+            StudioUI.instance = undefined;
+        }
     }
 
     /**

--- a/src/tests/utils/sdkTeardown.test.ts
+++ b/src/tests/utils/sdkTeardown.test.ts
@@ -1,0 +1,71 @@
+import { teardownSdk } from '../../utils/sdkTeardown';
+
+describe('teardownSdk', () => {
+    const EDITOR_ID = 'studio-ui-chili-editor';
+    let container: HTMLElement;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = EDITOR_ID;
+        document.body.appendChild(container);
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        container.remove();
+        warnSpy.mockRestore();
+    });
+
+    it('destroys the sdk and removes the engine iframe', () => {
+        container.appendChild(document.createElement('iframe'));
+        const destroy = jest.fn();
+
+        teardownSdk({ destroy }, EDITOR_ID);
+
+        expect(destroy).toHaveBeenCalledTimes(1);
+        expect(container.getElementsByTagName('iframe')).toHaveLength(0);
+    });
+
+    it('falls back to the connection when the sdk has no destroy', () => {
+        const connectionDestroy = jest.fn();
+
+        teardownSdk({ connection: { destroy: connectionDestroy } }, EDITOR_ID);
+
+        expect(connectionDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('only removes iframes inside the editor container', () => {
+        const outsider = document.createElement('iframe');
+        document.body.appendChild(outsider);
+        container.appendChild(document.createElement('iframe'));
+
+        teardownSdk({}, EDITOR_ID);
+
+        expect(container.getElementsByTagName('iframe')).toHaveLength(0);
+        expect(outsider.isConnected).toBe(true);
+        outsider.remove();
+    });
+
+    it('still removes the iframe when shutting the sdk down throws', () => {
+        container.appendChild(document.createElement('iframe'));
+
+        teardownSdk(
+            {
+                destroy: () => {
+                    throw new Error('already destroyed');
+                },
+            },
+            EDITOR_ID,
+        );
+
+        // The engine would leak if a failing destroy aborted the rest of the teardown.
+        expect(container.getElementsByTagName('iframe')).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('is a no-op for a missing sdk or container', () => {
+        expect(() => teardownSdk(undefined, EDITOR_ID)).not.toThrow();
+        expect(() => teardownSdk({}, 'does-not-exist')).not.toThrow();
+    });
+});

--- a/src/utils/sdkTeardown.ts
+++ b/src/utils/sdkTeardown.ts
@@ -1,37 +1,40 @@
+/** The part of an SDK instance needed to shut it down, across studio-sdk versions. */
+type ShutdownableSdk = { destroy?: () => void; connection?: { destroy?: () => void } };
+
 /**
  * Shuts an SDK instance down and removes the engine iframe it created.
  *
- * Every mounted Studio UI creates its own engine, and an engine that is not torn down
- * keeps its whole realm alive - the Dart heap plus the CanvasKit and QuickJS WASM
- * memory, which is roughly 190MB per instance. Removing the iframe is what actually
- * lets the browser discard that realm.
+ * Every mounted Studio UI creates its own engine, and an engine that is not torn down keeps
+ * its whole realm alive - the Dart heap plus the CanvasKit and QuickJS WASM memory, roughly
+ * 190MB per instance. Removing the iframe is what lets the browser discard that realm.
  *
- * `SDK.destroy()` only exists from studio-sdk 1.46 onwards, so this falls back to
- * destroying the postMessage connection and removing the iframe by hand. Both paths are
- * idempotent, and neither is allowed to throw: teardown runs during React unmount, where
- * an exception would skip the rest of the cleanup.
+ * `SDK.destroy()` only exists from studio-sdk 1.46 onwards, so older versions fall back to
+ * destroying the postMessage connection. Both are idempotent, so running them in turn is
+ * safe either way.
  *
  * @param sdk The SDK instance to shut down.
  * @param editorContainerId Id of the element the engine iframe was appended to.
  */
 export const teardownSdk = (sdk: unknown, editorContainerId: string) => {
-    const instance = sdk as { destroy?: () => void; connection?: { destroy?: () => void } } | undefined;
+    const instance = sdk as ShutdownableSdk | undefined;
 
-    try {
-        instance?.destroy?.();
-    } catch {
-        // An already destroyed instance must not block the rest of the teardown.
+    const shutdownSteps = [() => instance?.destroy?.(), () => instance?.connection?.destroy?.()];
+
+    for (const shutdown of shutdownSteps) {
+        try {
+            shutdown();
+        } catch (error) {
+            // Teardown runs while a component is unmounting. Rethrowing here would skip the
+            // iframe removal below and leak the engine, so the failure is reported instead.
+            // penpal's own iframe-removal monitor may also have closed the connection first.
+            // eslint-disable-next-line no-console
+            console.warn('Studio SDK teardown step failed:', error);
+        }
     }
 
-    try {
-        instance?.connection?.destroy?.();
-    } catch {
-        // penpal's own iframe-removal monitor may have destroyed it already.
-    }
-
-    // Scoped to the editor container on purpose. Looking the iframe up document-wide
-    // would pick the first iframe on the page, which in an embedded setup is somebody
-    // else's frame rather than this engine.
+    // Scoped to the editor container on purpose. Looking the iframe up document-wide would
+    // pick the first iframe on the page, which in an embedded setup is somebody else's
+    // frame rather than this engine.
     document
         .getElementById(editorContainerId)
         ?.querySelectorAll('iframe')

--- a/src/utils/sdkTeardown.ts
+++ b/src/utils/sdkTeardown.ts
@@ -1,0 +1,39 @@
+/**
+ * Shuts an SDK instance down and removes the engine iframe it created.
+ *
+ * Every mounted Studio UI creates its own engine, and an engine that is not torn down
+ * keeps its whole realm alive - the Dart heap plus the CanvasKit and QuickJS WASM
+ * memory, which is roughly 190MB per instance. Removing the iframe is what actually
+ * lets the browser discard that realm.
+ *
+ * `SDK.destroy()` only exists from studio-sdk 1.46 onwards, so this falls back to
+ * destroying the postMessage connection and removing the iframe by hand. Both paths are
+ * idempotent, and neither is allowed to throw: teardown runs during React unmount, where
+ * an exception would skip the rest of the cleanup.
+ *
+ * @param sdk The SDK instance to shut down.
+ * @param editorContainerId Id of the element the engine iframe was appended to.
+ */
+export const teardownSdk = (sdk: unknown, editorContainerId: string) => {
+    const instance = sdk as { destroy?: () => void; connection?: { destroy?: () => void } } | undefined;
+
+    try {
+        instance?.destroy?.();
+    } catch {
+        // An already destroyed instance must not block the rest of the teardown.
+    }
+
+    try {
+        instance?.connection?.destroy?.();
+    } catch {
+        // penpal's own iframe-removal monitor may have destroyed it already.
+    }
+
+    // Scoped to the editor container on purpose. Looking the iframe up document-wide
+    // would pick the first iframe on the page, which in an embedded setup is somebody
+    // else's frame rather than this engine.
+    document
+        .getElementById(editorContainerId)
+        ?.querySelectorAll('iframe')
+        .forEach((iframe) => iframe.remove());
+};


### PR DESCRIPTION
## Related tickets

-   [AIML-40](https://chilipublishintranet.atlassian.net/browse/AIML-40)

## Problem

Entering and leaving run mode twice grew the tab from 278MB to 708MB, ~250MB per visit, never reclaimed. A heap snapshot showed **three complete, fully live engines** in one page. Studio UI is where the run-mode engine is mounted, and nothing ever shut a previous one down.

Depends on chili-publish/studio-sdk#812 for the full fix, but works against the currently pinned SDK too (see the fallback below).

## Root causes in studio-ui

**1. The "already instantiated" guard could never fire** — `deprecated-loaders.tsx`:

```ts
if (this.root) { throw new Error('Studio UI component is already instantiated...'); }
```

`this.root` is an instance field on a freshly constructed object, so it is always `undefined` here. A second mount silently created a second React root and a second engine.

**2. Nothing destroyed the previous instance.** `destroy()` existed but was only wired into the back-button `onBack` closure — never into the loader entry points.

**3. The effect cleanup removed the wrong iframe** — `MainContent.tsx`:

```ts
const iframeContainer = document.getElementsByTagName('iframe')[0];
iframeContainer?.remove();
```

That is the first iframe on the *page*, not this engine's. In an embedded setup it is somebody else's frame. The cleanup also never closed the SDK connection.

**4. `window.StudioUISDK` / `window.SDK` outlive the component**, pinning the SDK and through it the engine realm for the lifetime of the page.

## Why a live iframe reference is so expensive

Each engine realm holds a 32MB CanvasKit `HEAP8`, two 16MB QuickJS runtimes, and a dart2js heap that exclusively retained **128.2MB** in the snapshot — roughly 190MB of JS heap per instance. Removing the iframe *and* dropping every reference to it is what lets the browser discard the realm and all of that at once.

## Changes

- Track mounted selectors statically so the guard actually works.
- Destroy the previous instance in `fullStudioIntegrationConfig`, the single funnel every loader entry point goes through.
- `override destroy()` on `StudioUI` clears the static `instance`; the base `destroy()` clears the container so anything the SDK appended outside React's tree is dropped too.
- New `utils/sdkTeardown.ts`: prefers `SDK.destroy()` (studio-sdk 1.46+), otherwise destroys the connection and removes the iframe **scoped to `EDITOR_ID`**. Idempotent and never throws — it runs during unmount, where an exception would skip the rest of the cleanup.
- Release `window.StudioUISDK` / `window.SDK` (only when they still point at this instance) and reset `sdkRef`.

## Verification

⚠️ I could not build or test this repo locally: `node_modules` is absent and installing needs GitHub Packages access that this machine's token lacks (`read:packages` missing). Please let CI confirm.

What I did verify:
- Syntax-checked all four touched files with `tsc` (remaining diagnostics are `--noResolve` artifacts only).
- `prettier --check` passes on all four files against this repo's `.prettierrc.cjs`.
- Reviewed against `strict: true` / TS 5.1: `override` is valid (`StudioUI extends StudioUILoader`), and `selector` is definitely assigned in the constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AIML-40]: https://chilipublishintranet.atlassian.net/browse/AIML-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ