### PR TITLE
[Fix][GRAFX-6469] Migrate GitHub actions to latest majors

### DIFF
--- a/.github/actions/commit-version-changes/action.yml
+++ b/.github/actions/commit-version-changes/action.yml
@@ -46,8 +46,7 @@ runs:
 
               # Push the branch (tag will be created and pushed later after validation)
               echo "Pushing branch: $BRANCH_TO_PUSH"
-              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-              git push origin "$BRANCH_TO_PUSH"
+              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH_TO_PUSH"
 
               echo "✅ Version branch pushed to $BRANCH_TO_PUSH"
           env:

--- a/.github/actions/commit-version-changes/action.yml
+++ b/.github/actions/commit-version-changes/action.yml
@@ -46,6 +46,7 @@ runs:
 
               # Push the branch (tag will be created and pushed later after validation)
               echo "Pushing branch: $BRANCH_TO_PUSH"
+              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
               git push origin "$BRANCH_TO_PUSH"
 
               echo "✅ Version branch pushed to $BRANCH_TO_PUSH"

--- a/.github/actions/merge-and-delete-branch/action.yml
+++ b/.github/actions/merge-and-delete-branch/action.yml
@@ -30,8 +30,7 @@ runs:
               git merge "$SOURCE_BRANCH" --strategy=ours --no-edit -m "chore: merge version bump commit [skip ci]"
 
               # Push the target branch with merge commit
-              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-              git push origin "$TARGET_BRANCH"
+              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TARGET_BRANCH"
           env:
               GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
@@ -47,8 +46,7 @@ runs:
               }
 
               # Delete remote branch
-              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-              git push origin --delete "$SOURCE_BRANCH" || echo "⚠️  Remote branch $SOURCE_BRANCH not found or already deleted"
+              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --delete "$SOURCE_BRANCH" || echo "⚠️  Remote branch $SOURCE_BRANCH not found or already deleted"
 
               # Delete local branch
               git branch -D "$SOURCE_BRANCH" || echo "⚠️  Local branch $SOURCE_BRANCH not found or already deleted"

--- a/.github/actions/merge-and-delete-branch/action.yml
+++ b/.github/actions/merge-and-delete-branch/action.yml
@@ -30,6 +30,7 @@ runs:
               git merge "$SOURCE_BRANCH" --strategy=ours --no-edit -m "chore: merge version bump commit [skip ci]"
 
               # Push the target branch with merge commit
+              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
               git push origin "$TARGET_BRANCH"
           env:
               GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -46,6 +47,7 @@ runs:
               }
 
               # Delete remote branch
+              git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
               git push origin --delete "$SOURCE_BRANCH" || echo "⚠️  Remote branch $SOURCE_BRANCH not found or already deleted"
 
               # Delete local branch

--- a/.github/workflows/bundle-size-update.yml
+++ b/.github/workflows/bundle-size-update.yml
@@ -14,22 +14,22 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   token: ${{ steps.github-app-access-token.outputs.token }}
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/bundle-size-update.yml
+++ b/.github/workflows/bundle-size-update.yml
@@ -20,10 +20,13 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
+                  repositories: ${{ github.repository }}
+                  permission-contents: write
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   token: ${{ steps.github-app-access-token.outputs.token }}
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -56,9 +59,12 @@ jobs:
                   new_bundle_size=${{ steps.get_new_bundle_size.outputs.new_bundle_size }}
                   echo "{ \"bundle_size\": $new_bundle_size }" > bundle-size.json
             - name: Commit and push updated bundle size
+              env:
+                  APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
               run: |
                   git config --global user.name 'github-actions[bot]'
                   git config --global user.email user.email 'github-actions[bot]@users.noreply.github.com'
                   git add bundle-size.json
                   git commit -m "Update bundle size [skip ci]"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin main --follow-tags

--- a/.github/workflows/bundle-size-update.yml
+++ b/.github/workflows/bundle-size-update.yml
@@ -66,5 +66,4 @@ jobs:
                   git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                   git add bundle-size.json
                   git commit -m "Update bundle size [skip ci]"
-                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
-                  git push origin main --follow-tags
+                  git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" HEAD:main --follow-tags

--- a/.github/workflows/bundle-size-update.yml
+++ b/.github/workflows/bundle-size-update.yml
@@ -63,7 +63,7 @@ jobs:
                   APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
               run: |
                   git config --global user.name 'github-actions[bot]'
-                  git config --global user.email user.email 'github-actions[bot]@users.noreply.github.com'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                   git add bundle-size.json
                   git commit -m "Update bundle size [skip ci]"
                   git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"

--- a/.github/workflows/bundle-size-update.yml
+++ b/.github/workflows/bundle-size-update.yml
@@ -6,6 +6,7 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
     packages: read
 jobs:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,6 +26,7 @@ env:
     NODE_VERSION: 22.x
     RELEASES_LIMIT: 10
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
     configure-parameters:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -95,20 +95,20 @@ jobs:
                   echo "workflow_branch=$WORKFLOW_BRANCH" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -194,20 +194,20 @@ jobs:
                   echo "workflow_branch=$WORKFLOW_BRANCH" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -301,20 +301,20 @@ jobs:
                   echo "workflow_branch=$WORKFLOW_BRANCH" >> $GITHUB_ENV
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -503,13 +503,13 @@ jobs:
                   fi
 
             - name: Checkout version branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ steps.version.outputs.version_branch }}
 
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -518,7 +518,7 @@ jobs:
                       ${{ runner.os }}-node-
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
@@ -559,13 +559,13 @@ jobs:
                   fi
 
             - name: Checkout version branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ steps.version.outputs.version_branch }}
 
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -574,7 +574,7 @@ jobs:
                       ${{ runner.os }}-node-
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
@@ -614,7 +614,7 @@ jobs:
                   fi
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
@@ -673,7 +673,7 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
@@ -709,7 +709,7 @@ jobs:
                   fi
 
             - name: Checkout version branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ steps.version.outputs.version_branch }}
                   fetch-depth: 0
@@ -761,7 +761,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Notify Teams success
               uses: ./.github/actions/cd-notify
@@ -805,7 +805,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Determine failed step
               id: failed-step

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,6 @@ env:
     NODE_VERSION: 22.x
     RELEASES_LIMIT: 10
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
-    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
     configure-parameters:
@@ -98,6 +97,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
@@ -197,6 +197,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
@@ -304,6 +305,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
@@ -506,6 +508,7 @@ jobs:
             - name: Checkout version branch
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: ${{ steps.version.outputs.version_branch }}
 
             - name: Check cache
@@ -562,6 +565,7 @@ jobs:
             - name: Checkout version branch
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: ${{ steps.version.outputs.version_branch }}
 
             - name: Check cache
@@ -617,6 +621,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
 
             - name: Configure git
@@ -633,6 +638,7 @@ jobs:
                   echo "⚠️  Deleting temporary version branch: $BRANCH"
 
                   # Delete the remote temporary branch
+                  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin --delete "$BRANCH"
 
                   echo "✅ Cleanup complete: Temporary branch deleted"
@@ -647,6 +653,8 @@ jobs:
 
                   echo "⚠️  Preflight failed - reverting version change commit"
                   echo "⚠️  Branch: $BRANCH, Commit: $COMMIT_SHA"
+
+                  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
                   # Checkout the branch and pull latest changes
                   git fetch origin "$BRANCH"
@@ -680,6 +688,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
                   repositories: ${{ github.repository }}
+                  permission-contents: write
             - name: Extract version outputs
               id: version
               run: |
@@ -713,11 +722,14 @@ jobs:
             - name: Checkout version branch
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: ${{ steps.version.outputs.version_branch }}
                   fetch-depth: 0
                   token: ${{ steps.github-app-access-token.outputs.token }}
 
             - name: Create and push tag
+              env:
+                  APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
               run: |
                   TAG="${{ steps.version.outputs.tag_name }}"
                   COMMIT_SHA="${{ steps.version.outputs.version_commit_sha }}"
@@ -727,6 +739,7 @@ jobs:
                   # Configure git to use the token
                   git config user.name 'github-actions[bot]'
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
                   # Create the tag
                   git tag "$TAG" "$COMMIT_SHA"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -679,6 +679,7 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
+                  repositories: studio-ui
             - name: Extract version outputs
               id: version
               run: |
@@ -763,6 +764,8 @@ jobs:
             contents: read
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
 
             - name: Notify Teams success
               uses: ./.github/actions/cd-notify
@@ -807,6 +810,8 @@ jobs:
             contents: read
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
 
             - name: Determine failed step
               id: failed-step

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -679,7 +679,7 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
-                  repositories: studio-ui
+                  repositories: ${{ github.repository }}
             - name: Extract version outputs
               id: version
               run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -638,8 +638,7 @@ jobs:
                   echo "⚠️  Deleting temporary version branch: $BRANCH"
 
                   # Delete the remote temporary branch
-                  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-                  git push origin --delete "$BRANCH"
+                  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" --delete "$BRANCH"
 
                   echo "✅ Cleanup complete: Temporary branch deleted"
               env:
@@ -654,18 +653,18 @@ jobs:
                   echo "⚠️  Preflight failed - reverting version change commit"
                   echo "⚠️  Branch: $BRANCH, Commit: $COMMIT_SHA"
 
-                  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+                  AUTH_ORIGIN="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
                   # Checkout the branch and pull latest changes
-                  git fetch origin "$BRANCH"
+                  git fetch "$AUTH_ORIGIN" "$BRANCH"
                   git checkout "$BRANCH"
-                  git pull origin "$BRANCH" || echo "Pull failed or already up to date"
+                  git pull "$AUTH_ORIGIN" "$BRANCH" || echo "Pull failed or already up to date"
 
                   # Revert the version change commit
                   git revert "$COMMIT_SHA" --no-edit
 
                   # Push the revert commit
-                  git push origin "$BRANCH"
+                  git push "$AUTH_ORIGIN" "$BRANCH"
 
                   echo "✅ Cleanup complete: Version change commit reverted, branch kept"
               env:
@@ -739,13 +738,12 @@ jobs:
                   # Configure git to use the token
                   git config user.name 'github-actions[bot]'
                   git config user.email 'github-actions[bot]@users.noreply.github.com'
-                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
 
                   # Create the tag
                   git tag "$TAG" "$COMMIT_SHA"
 
                   # Push the tag
-                  git push origin "$TAG"
+                  git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "$TAG"
 
                   echo "✅ Successfully created and pushed tag"
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -8,6 +8,7 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
     validate-tag-release:
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -256,6 +256,7 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
+                  repositories: delivery-infrastructure
 
             - name: Dispatch Cloudflare CDN Purge Action
               id: dispatch-cloudflare-cdn-purge
@@ -275,6 +276,8 @@ jobs:
             contents: read
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
 
             - name: Notify Teams success
               uses: ./.github/actions/cd-notify
@@ -309,12 +312,14 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
+                  repositories: studio-ui
 
             - name: Checkout main branch
               uses: actions/checkout@v7
               with:
                   ref: main
                   token: ${{ steps.github-app-access-token.outputs.token }}
+                  persist-credentials: false
                   fetch-depth: 0
 
             - name: Setup Node.js
@@ -393,9 +398,12 @@ jobs:
 
             - name: Commit and push version bump
               if: steps.check_hotfix.outputs.is_hotfix != 'true'
+              env:
+                  APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
               run: |
                   git add package.json yarn.lock || true
                   git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }} for next dev cycle [skip ci]"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin main
                   echo "Pushed version bump to main branch"
 
@@ -424,6 +432,8 @@ jobs:
             contents: read
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
 
             - name: Determine failed step
               id: failed-step

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -8,7 +8,6 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
-    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
     validate-tag-release:
         runs-on: ubuntu-latest
@@ -21,6 +20,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: ${{ github.ref }}
                   fetch-depth: 0
 
@@ -168,6 +168,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: ${{ needs.detect-release-type.outputs.tag_name }}
 
             - name: Check cache
@@ -257,6 +258,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
                   repositories: delivery-infrastructure
+                  permission-actions: write
 
             - name: Dispatch Cloudflare CDN Purge Action
               id: dispatch-cloudflare-cdn-purge
@@ -313,13 +315,14 @@ jobs:
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
                   repositories: ${{ github.repository }}
+                  permission-contents: write
 
             - name: Checkout main branch
               uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   ref: main
                   token: ${{ steps.github-app-access-token.outputs.token }}
-                  persist-credentials: false
                   fetch-depth: 0
 
             - name: Setup Node.js

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -18,7 +18,7 @@ jobs:
             tag_name: ${{ steps.validate_release.outputs.tag_name }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.ref }}
                   fetch-depth: 0
@@ -165,13 +165,13 @@ jobs:
             packages: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: ${{ needs.detect-release-type.outputs.tag_name }}
 
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -180,7 +180,7 @@ jobs:
                       ${{ runner.os }}-node-
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
@@ -250,7 +250,7 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
@@ -273,7 +273,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Notify Teams success
               uses: ./.github/actions/cd-notify
@@ -303,21 +303,21 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
 
             - name: Checkout main branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: main
                   token: ${{ steps.github-app-access-token.outputs.token }}
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
@@ -325,7 +325,7 @@ jobs:
 
             - name: Check cache
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       node_modules
@@ -422,7 +422,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Determine failed step
               id: failed-step

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -312,7 +312,7 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
-                  repositories: studio-ui
+                  repositories: ${{ github.repository }}
 
             - name: Checkout main branch
               uses: actions/checkout@v7

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -406,8 +406,7 @@ jobs:
               run: |
                   git add package.json yarn.lock || true
                   git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }} for next dev cycle [skip ci]"
-                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
-                  git push origin main
+                  git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" HEAD:main
                   echo "Pushed version bump to main branch"
 
     notify-teams-failure:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
     contents: write
     packages: read

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,14 +17,14 @@ jobs:
                 shard: [1, 2, 3, 4, 5]
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -43,7 +43,7 @@ jobs:
                   mv coverage/lcov.info coverage/lcov-${{matrix.shard}}.info
                   mv coverage/coverage-final.json coverage/coverage-final-${{matrix.shard}}.json
             - name: Use UploadArtifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: coverage-artifacts-${{ matrix.shard }}
                   path: |
@@ -55,13 +55,13 @@ jobs:
         needs: [run-tests]
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
-            - uses: actions/upload-artifact/merge@v4
+            - uses: actions/upload-artifact/merge@v7
               with:
                   name: coverage-artifacts
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: coverage-artifacts
                   path: coverage
@@ -82,14 +82,14 @@ jobs:
         name: build (20)
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -107,7 +107,7 @@ jobs:
             - name: build code
               run: yarn build
             - name: 'Comment on PR'
-              uses: actions/github-script@0.3.0
+              uses: actions/github-script@v9
               if: github.event_name == 'pull_request'
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
                       const formattedSize = formatBytes(stats.size,3);
                       const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
 
-                      github.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
+                      await github.rest.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
             - name: copy file branch
               run: |
                   buildPath=upload/pr_builds/$CI_REF_NAME
@@ -172,14 +172,14 @@ jobs:
         timeout-minutes: 60
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -189,7 +189,7 @@ jobs:
               run: yarn install
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               id: playwright-cache
               with:
                   path: ~/.cache/ms-playwright
@@ -210,7 +210,7 @@ jobs:
                   GITHUB_PR_NUMBER: ${{ steps.extract-pr-number.outputs.pr_number }}
                   INTEGRATION_CLIENT_ID: ${{ secrets.INTEGRATION_CLIENT_ID }}
                   INTEGRATION_CLIENT_SECRET: ${{ secrets.INTEGRATION_CLIENT_SECRET }}
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               if: ${{ !cancelled() }}
               with:
                   name: playwright-report

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,6 +19,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -58,6 +60,7 @@ jobs:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
+                  persist-credentials: false
                   fetch-depth: 0
             - uses: actions/upload-artifact/merge@v7
               with:
@@ -84,6 +87,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -174,6 +179,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -6,6 +6,7 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
     contents: read
     packages: read

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -250,5 +250,4 @@ jobs:
                   git add package.json README.md
                   git commit -m "CI: Bump version to $VERSION [skip ci]"
                   git tag "$VERSION"
-                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
-                  git push origin main --follow-tags
+                  git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" HEAD:main --follow-tags

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -20,6 +20,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -64,6 +66,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - uses: actions/upload-artifact/merge@v7
               with:
                   name: coverage-artifacts
@@ -86,6 +90,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -116,6 +122,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:
@@ -185,6 +193,8 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
+                  repositories: delivery-infrastructure
+                  permission-actions: write
 
             - name: Dispatch Cloudflare CDN Purge Action
               id: dispatch-cloudflare-cdn-purge
@@ -206,7 +216,7 @@ jobs:
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
-                  owner: ${{ github.repository_owner }}
+                  permission-contents: write
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -6,7 +6,6 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
-    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
     contents: read
     packages: read
@@ -222,6 +221,7 @@ jobs:
               with:
                   ref: main
                   token: ${{ steps.github-app-access-token.outputs.token }}
+                  persist-credentials: false
                   fetch-depth: 0
             - uses: actions/download-artifact@v8
               with:
@@ -243,9 +243,12 @@ jobs:
                   git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                   npm version prerelease --preid=alpha --git-tag-version=false
             - name: Push new version
+              env:
+                  APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
               run: |
                   VERSION=$(jq -r .version < package.json)
                   git add package.json README.md
                   git commit -m "CI: Bump version to $VERSION [skip ci]"
                   git tag "$VERSION"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
                   git push origin main --follow-tags

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -18,14 +18,14 @@ jobs:
                 shard: [1, 2, 3, 4, 5]
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -46,7 +46,7 @@ jobs:
                   mv coverage/lcov.info coverage/lcov-${{matrix.shard}}.info
                   mv coverage/coverage-final.json coverage/coverage-final-${{matrix.shard}}.json
             - name: Use UploadArtifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: coverage-artifacts-${{ matrix.shard }}
                   path: |
@@ -62,11 +62,11 @@ jobs:
             report_name: ${{ steps.set-output.outputs.report_name }}
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
-            - uses: actions/upload-artifact/merge@v4
+            - uses: actions/checkout@v7
+            - uses: actions/upload-artifact/merge@v7
               with:
                   name: coverage-artifacts
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: coverage-artifacts
                   path: coverage
@@ -76,7 +76,7 @@ jobs:
               id: set-output
               run: echo "report_name=${{ env.COVERAGE_REPORT_NAME }}" >> $GITHUB_OUTPUT
             - name: Upload coverage report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ env.COVERAGE_REPORT_NAME }}
                   path: coverage
@@ -84,14 +84,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -114,14 +114,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -179,7 +179,7 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
@@ -201,23 +201,23 @@ jobs:
         steps:
             - name: Get GitHub App Access Token
               id: github-app-access-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   owner: ${{ github.repository_owner }}
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   ref: main
                   token: ${{ steps.github-app-access-token.outputs.token }}
                   fetch-depth: 0
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: ${{ needs.prepare-coverage.outputs.report_name }}
                   path: coverage
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/pr-preflight.yml
+++ b/.github/workflows/pr-preflight.yml
@@ -14,6 +14,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: validate package versions
               run: yarn validate-versions
     check-bundle-size:
@@ -21,6 +23,8 @@ jobs:
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Use Node ${{ env.NODE_VERSION }}
               uses: actions/setup-node@v7
               with:

--- a/.github/workflows/pr-preflight.yml
+++ b/.github/workflows/pr-preflight.yml
@@ -6,6 +6,7 @@ on:
 env:
     NODE_VERSION: 22.x
     FONTAWESOME_NPM_TOKEN: ${{ secrets.FONTAWESOME_NPM_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:
     packages: read
 jobs:

--- a/.github/workflows/pr-preflight.yml
+++ b/.github/workflows/pr-preflight.yml
@@ -12,21 +12,21 @@ jobs:
     validate-versions:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: validate package versions
               run: yarn validate-versions
     check-bundle-size:
         runs-on: ubuntu-latest
         steps:
             - uses: FranzDiebold/github-env-vars-action@v2
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Use Node ${{ env.NODE_VERSION }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@chili-publish'
-            - uses: actions/cache@v4
+            - uses: actions/cache@v6
               with:
                   path: ~/.cache/yarn
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/trigger-automated-tests.yml
+++ b/.github/workflows/trigger-automated-tests.yml
@@ -8,6 +8,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Skip tests notification
               if: github.event.label.name == 'Skip QA'
               run: |
@@ -22,6 +24,8 @@ jobs:
                   gh-app-id: ${{ vars.GH_APP_ID_CHILI_REPO_ACTIONS }}
 
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Get GitHub application installation access token
               id: get-gh-app-installation-access-token
               if: github.event.label.name == 'Ready for QA'
@@ -50,6 +54,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - name: Skip tests notification
               if: github.event.label.name == 'Skip QA'
               run: |

--- a/.github/workflows/trigger-automated-tests.yml
+++ b/.github/workflows/trigger-automated-tests.yml
@@ -7,7 +7,7 @@ jobs:
         if: github.event.label.name == 'Ready for QA'  || github.event.label.name == 'Skip QA'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Skip tests notification
               if: github.event.label.name == 'Skip QA'
               run: |
@@ -21,7 +21,7 @@ jobs:
                   gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_REPO_ACTIONS }}
                   gh-app-id: ${{ vars.GH_APP_ID_CHILI_REPO_ACTIONS }}
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Get GitHub application installation access token
               id: get-gh-app-installation-access-token
               if: github.event.label.name == 'Ready for QA'
@@ -49,7 +49,7 @@ jobs:
         if: github.event.label.name == 'Ready for QA'  || github.event.label.name == 'Skip QA'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Skip tests notification
               if: github.event.label.name == 'Skip QA'
               run: |


### PR DESCRIPTION
This PR

## Related tickets

- [GRAFX-6469](https://chilipublishintranet.atlassian.net/browse/GRAFX-6469)

## Screenshots

N/A — CI workflow pin migration only.


[GRAFX-6469]: https://chilipublishintranet.atlassian.net/browse/GRAFX-6469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ