### PR TITLE
[Fix][GRAFX-6528] Pin third-party GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly

--- a/.github/workflows/check-description.yml
+++ b/.github/workflows/check-description.yml
@@ -2,6 +2,7 @@ name: Check PR description for JIRA ticket
 on:
     pull_request:
         types: [opened, labeled]
+permissions: {}
 jobs:
     check-description:
         runs-on: ubuntu-latest
@@ -12,7 +13,7 @@ jobs:
               with:
                   script: |
                       const body = context.payload.pull_request.body ?? '';
-                      const jiraPattern = /(?:https:\/\/[\w.-]+\.atlassian\.net\/browse\/|[A-Z][A-Z0-9]+-\d+)/i;
+                      const jiraPattern = /(?:https:\/\/[\w.-]+\.atlassian\.net\/browse\/)?\b[A-Z][A-Z0-9]+-\d+\b/i;
                       if (!jiraPattern.test(body)) {
                           core.setFailed('PR description must contain a JIRA ticket link or key (e.g. GRAFX-1234). Add the `No JIRA ticket` label to skip.');
                       }

--- a/.github/workflows/check-description.yml
+++ b/.github/workflows/check-description.yml
@@ -8,4 +8,11 @@ jobs:
         steps:
             - name: Check description of the Pull Request
               if: ${{!contains(github.event.pull_request.labels.*.name, 'No JIRA ticket')}}
-              uses: pkgacek/check-pr-description-for-jira-ticket@v1.6
+              uses: actions/github-script@v9
+              with:
+                  script: |
+                      const body = context.payload.pull_request.body ?? '';
+                      const jiraPattern = /(?:https:\/\/[\w.-]+\.atlassian\.net\/browse\/|[A-Z][A-Z0-9]+-\d+)/i;
+                      if (!jiraPattern.test(body)) {
+                          core.setFailed('PR description must contain a JIRA ticket link or key (e.g. GRAFX-1234). Add the `No JIRA ticket` label to skip.');
+                      }

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -226,7 +226,7 @@ jobs:
                   cp -R dist/* ${versionedLatestPath%"/merge"}
 
             - name: Azure Login
-              uses: azure/login@v2
+              uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
               with:
                   creds: >-
                       {
@@ -237,7 +237,7 @@ jobs:
                       }
 
             - name: Copy Studio UI to Azure Blob Storage
-              uses: azure/cli@v2
+              uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
               with:
                   inlineScript: |
                       az storage blob upload-batch \

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -146,14 +146,12 @@ jobs:
 
                       await github.rest.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
             - name: copy file branch
-              env:
-                  PR_HEAD_REF: ${{ github.head_ref }}
               run: |
-                  if [[ ! "$PR_HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+                  if [[ ! "$GITHUB_HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
                       echo "::error::Invalid branch name"
                       exit 1
                   fi
-                  buildPath="upload/pr_builds/${PR_HEAD_REF}"
+                  buildPath="upload/pr_builds/${GITHUB_HEAD_REF}"
                   targetDir="${buildPath%"/merge"}"
                   mkdir -p "$targetDir"
                   cp -R dist/* "$targetDir"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,7 +23,6 @@ jobs:
             matrix:
                 shard: [1, 2, 3, 4, 5]
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -61,7 +60,6 @@ jobs:
         runs-on: ubuntu-latest
         needs: [run-tests]
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -76,12 +74,12 @@ jobs:
             - name: Process Coverage
               run: npx nyc report --reporter lcov --reporter json --reporter html -t coverage
             - name: Publish Unit Test Results
-              uses: EnricoMi/publish-unit-test-result-action@v2
+              uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
               if: always()
               with:
                   files: coverage/**/*.xml
             - name: SonarQube analysis
-              uses: sonarsource/sonarqube-scan-action@master
+              uses: sonarsource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -89,7 +87,6 @@ jobs:
         runs-on: ubuntu-latest
         name: build (20)
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -150,11 +147,11 @@ jobs:
                       await github.rest.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
             - name: copy file branch
               run: |
-                  buildPath=upload/pr_builds/$CI_REF_NAME
+                  buildPath=upload/pr_builds/${{ github.head_ref }}
                   mkdir -p ${buildPath%"/merge"}
                   cp -R dist/* ${buildPath%"/merge"}
             - name: Azure Login
-              uses: azure/login@v2
+              uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
               with:
                   creds: >-
                       {
@@ -165,7 +162,7 @@ jobs:
                       }
 
             - name: Copy to Azure Blob Storage
-              uses: azure/cli@v2
+              uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
               with:
                   inlineScript: |
                       az storage blob upload-batch \
@@ -179,7 +176,6 @@ jobs:
         needs: [build]
         timeout-minutes: 60
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -146,10 +146,17 @@ jobs:
 
                       await github.rest.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
             - name: copy file branch
+              env:
+                  PR_HEAD_REF: ${{ github.head_ref }}
               run: |
-                  buildPath=upload/pr_builds/${{ github.head_ref }}
-                  mkdir -p ${buildPath%"/merge"}
-                  cp -R dist/* ${buildPath%"/merge"}
+                  if [[ ! "$PR_HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+                      echo "::error::Invalid branch name"
+                      exit 1
+                  fi
+                  buildPath="upload/pr_builds/${PR_HEAD_REF}"
+                  targetDir="${buildPath%"/merge"}"
+                  mkdir -p "$targetDir"
+                  cp -R dist/* "$targetDir"
             - name: Azure Login
               uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
               with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -146,13 +146,14 @@ jobs:
 
                       await github.rest.issues.createComment({ issue_number, owner, repo, body: 'PR bundle size is ' + formattedSize+ ' and ' +getSizeDif()+'.'  });
             - name: copy file branch
+              env:
+                  PR_NUMBER: ${{ github.event.number }}
               run: |
-                  if [[ ! "$GITHUB_HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-                      echo "::error::Invalid branch name"
+                  if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+                      echo "::error::Invalid PR number"
                       exit 1
                   fi
-                  buildPath="upload/pr_builds/${GITHUB_HEAD_REF}"
-                  targetDir="${buildPath%"/merge"}"
+                  targetDir="upload/pr_builds/${PR_NUMBER}"
                   mkdir -p "$targetDir"
                   cp -R dist/* "$targetDir"
             - name: Azure Login

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -24,7 +24,6 @@ jobs:
             matrix:
                 shard: [1, 2, 3, 4, 5]
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -68,7 +67,6 @@ jobs:
         outputs:
             report_name: ${{ steps.set-output.outputs.report_name }}
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -92,7 +90,6 @@ jobs:
     build-preflight:
         runs-on: ubuntu-latest
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -122,7 +119,6 @@ jobs:
         needs: [build-preflight, run-tests]
         runs-on: ubuntu-latest
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false
@@ -172,7 +168,7 @@ jobs:
                   cp -R dist/* ${latestPath%"/merge"}
                   cp -R dist/* ${versionedLatestPath%"/merge"}
             - name: Azure Login
-              uses: azure/login@v2
+              uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
               with:
                   creds: >-
                       {
@@ -183,7 +179,7 @@ jobs:
                       }
 
             - name: Copy to Azure Blob Storage
-              uses: azure/cli@v2
+              uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
               with:
                   inlineScript: |
                       az storage blob upload-batch \
@@ -229,7 +225,6 @@ jobs:
                   app-id: ${{ vars.GH_APP_ID_CHILI_FRONTEND_VERSION_MANAGER }}
                   private-key: ${{ secrets.GH_APP_PRIVATE_KEY_CHILI_FRONTEND_VERSION_MANAGER }}
                   permission-contents: write
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   ref: main

--- a/.github/workflows/pr-preflight.yml
+++ b/.github/workflows/pr-preflight.yml
@@ -27,7 +27,6 @@ jobs:
     check-bundle-size:
         runs-on: ubuntu-latest
         steps:
-            - uses: FranzDiebold/github-env-vars-action@v2
             - uses: actions/checkout@v7
               with:
                   persist-credentials: false

--- a/.github/workflows/trigger-automated-tests.yml
+++ b/.github/workflows/trigger-automated-tests.yml
@@ -2,6 +2,8 @@ name: Trigger the automated tests
 on:
     pull_request:
         types: [labeled]
+permissions:
+    contents: read
 jobs:
     trigger-gauge-tests:
         if: github.event.label.name == 'Ready for QA'  || github.event.label.name == 'Skip QA'

--- a/.github/workflows/trigger-automated-tests.yml
+++ b/.github/workflows/trigger-automated-tests.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Trigger the gauge tests
               if: github.event.label.name == 'Ready for QA'
-              uses: convictional/trigger-workflow-and-wait@v1.6.1
+              uses: convictional/trigger-workflow-and-wait@924e4984551efec603bec665c0663332498c381a # v1.6.1
               with:
                   owner: chili-publish
                   repo: editor-qa-framework
@@ -79,7 +79,7 @@ jobs:
 
             - name: Trigger the Playwright tests in qa-playwright-framework
               if: github.event.label.name == 'Ready for QA'
-              uses: convictional/trigger-workflow-and-wait@v1.6.1
+              uses: convictional/trigger-workflow-and-wait@924e4984551efec603bec665c0663332498c381a # v1.6.1
               with:
                   owner: chili-publish
                   repo: qa-playwright-framework


### PR DESCRIPTION
This PR

## Related tickets

- [GRAFX-6528](https://chilipublishintranet.atlassian.net/browse/GRAFX-6528)

## Summary

- SHA-pin third-party GitHub Actions (Azure login/cli v3, Sonar v8.2.1, others on current majors)
- Replace pkgacek, FranzDiebold, martinbeentjes, and actions-ecosystem steps with first-party equivalents
- Add weekly github-actions Dependabot updates

[GRAFX-6528]: https://chilipublishintranet.atlassian.net/browse/GRAFX-6528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ