### PR TITLE
[Fix][MAIN-2927] Bump studio-sdk to 1.47.0-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.28.6",
         "@chili-publish/environment-client-api": "0.31.59",
         "@chili-publish/grafx-shared-components": "1.8.1",
-        "@chili-publish/studio-sdk": "1.46.0-alpha.10",
+        "@chili-publish/studio-sdk": "1.47.0-alpha.3",
         "@fortawesome/fontawesome-svg-core": "^6.7.1",
         "@fortawesome/pro-light-svg-icons": "^6.7.1",
         "@fortawesome/pro-regular-svg-icons": "^6.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,10 +1325,10 @@
   resolved "https://npm.pkg.github.com/download/@chili-publish/grafx-shared-components/1.8.1/f250fb0aba184e2b97b48ed2955c06f1c70c5f6d#f250fb0aba184e2b97b48ed2955c06f1c70c5f6d"
   integrity sha512-sAndgMUB14DIJzln+mOWOsmtVhR+4oF3KgGW6+yqJYe84fS77v0VXAUgbtaCh+ojMTm/45JxJKvkRvBfsp2Mhg==
 
-"@chili-publish/studio-sdk@1.46.0-alpha.10":
-  version "1.46.0-alpha.10"
-  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.46.0-alpha.10/eb6fbddd644e36e00b0075731ae4fda4b0766790#eb6fbddd644e36e00b0075731ae4fda4b0766790"
-  integrity sha512-zYQl4JeSgYqDWrV773GfSxtKENX5gV4W2uYgJCFu1QFnOG/RH0dVgGqSu5rUIAxrp/f5FXVvGeDMI6LHU3lGpw==
+"@chili-publish/studio-sdk@1.47.0-alpha.3":
+  version "1.47.0-alpha.3"
+  resolved "https://npm.pkg.github.com/download/@chili-publish/studio-sdk/1.47.0-alpha.3/08993ead44e2667aed29242fab43c86619d934f1#08993ead44e2667aed29242fab43c86619d934f1"
+  integrity sha512-Xj78MRHRLJWoY2EedfN7fNLxcdnTXDorJfkyoz5WhXnQjjwRK+J2PGaylA1RGCDOxKSWIU7uZ6rUOZ/0y6xSEw==
   dependencies:
     penpal "6.1.0"
 
@@ -1727,8 +1727,6 @@
   version "6.7.1"
   resolved "https://npm.fontawesome.com/@fortawesome/pro-light-svg-icons/-/6.7.1/pro-light-svg-icons-6.7.1.tgz#26eb6d217b917f9e03f4c63701dc9e48e378e82c"
   integrity sha512-kG54DxnvwllajpJDaL+GJw2tlFHQo01BmHT14yOvgM6PNQ1mT1efNmGehNxvSx6CDuMHDSgS1neyut7q3it6dQ==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "6.7.1"
 
 "@fortawesome/pro-regular-svg-icons@^6.7.1":
   version "6.7.1"


### PR DESCRIPTION
This PR bumps `@chili-publish/studio-sdk` to `1.47.0-alpha.3` so Studio UI consumes studio-sdk main that includes the srcdoc-as-blob fix.

## Related tickets

- [MAIN-2927](https://chilipublishintranet.atlassian.net/browse/MAIN-2927)

## Screenshots


[MAIN-2927]: https://chilipublishintranet.atlassian.net/browse/MAIN-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ