### PR TITLE
[Fix] [WRS-3235] Revert filtering by availableItems

### DIFF
--- a/__mocks__/mockVariables.ts
+++ b/__mocks__/mockVariables.ts
@@ -106,7 +106,6 @@ export const mockVariables: [ImageVariable, ...Variable[]] = [
         items: [{ value: 'val 1', displayValue: 'Val 1' }, { value: 'val 2' }],
         isReadonly: false,
         isRequired: false,
-        availableItems: ['val 1', 'val 2'],
     },
 
     <BooleanVariable>{

--- a/src/components/variablesComponents/Variable.ts
+++ b/src/components/variablesComponents/Variable.ts
@@ -3,7 +3,6 @@ import {
     DataSourceVariable,
     DateVariable,
     ImageVariable,
-    ListVariableItem,
     LongTextVariable,
     NumberVariable,
     ShortTextVariable,
@@ -42,8 +41,4 @@ export const getVariableErrMsg = (variable: Variable) => {
     const isValid = variable.isRequired ? validateVariableValue(variable) : true;
 
     return !isValid ? 'This field is required' : '';
-};
-
-export const getVariableListItemsFilteredByAvailableItems = (variable: ListVariable): ListVariableItem[] => {
-    return variable.items.filter(({ value }) => variable.availableItems.includes(value));
 };

--- a/src/components/variablesComponents/listVariable/ListVariable.tsx
+++ b/src/components/variablesComponents/listVariable/ListVariable.tsx
@@ -6,7 +6,6 @@ import { ComponentWrapper } from '../../variables/VariablesPanel.styles';
 import { getVariablePlaceholder } from '../variablePlaceholder.util';
 import { HelpTextWrapper } from '../VariablesComponents.styles';
 import { IListVariable } from '../VariablesComponents.types';
-import { getVariableListItemsFilteredByAvailableItems } from '../Variable';
 
 const ListVariable = (props: IListVariable) => {
     const { variable, validationError, onChange } = props;
@@ -14,7 +13,7 @@ const ListVariable = (props: IListVariable) => {
 
     const [isDropdownOpen, setIsDropdownOpen] = useState<boolean | null>(null);
 
-    const options = getVariableListItemsFilteredByAvailableItems(variable).map((item) => ({
+    const options = variable.items.map((item) => ({
         label: item.displayValue || item.value,
         value: item.value,
     }));

--- a/src/tests/components/variablesComponents/listVariable/ListVariable.test.tsx
+++ b/src/tests/components/variablesComponents/listVariable/ListVariable.test.tsx
@@ -155,23 +155,4 @@ describe('ListVariable', () => {
             expect(options[i]).toHaveTextContent(new RegExp(item.value, 'i'));
         });
     });
-    it('should display filter list items by availableItems', async () => {
-        const user = userEvent.setup();
-        const variable = variables.find((item) => item.id === '10');
-        const listVariable = { ...variable, availableItems: ['val 2'] } as Type;
-        render(
-            <UiThemeProvider theme="platform">
-                <ListVariable variable={listVariable} onChange={jest.fn()} />;
-            </UiThemeProvider>,
-        );
-
-        const select = screen.getByRole('combobox', {
-            name: /select item/i,
-        });
-        expect(select).toBeInTheDocument();
-        await user.click(select);
-        const options = screen.getAllByRole('option');
-        expect(options).toHaveLength(1);
-        expect(options[0]).toHaveTextContent('val 2');
-    });
 });

--- a/src/tests/mocks/mockVariables.ts
+++ b/src/tests/mocks/mockVariables.ts
@@ -113,7 +113,6 @@ export const variablesWithGroups = [
         occurrences: 0,
         privateData: {},
         removeParagraphIfEmpty: false,
-        availableItems: ['1', '2', '3'],
     },
     {
         id: '8d9be0ee-3fe9-4b2f-82a4-2c60d122e186',


### PR DESCRIPTION
This PR Revert filtering by availableItems

## Related tickets

<!-- Prefer a JIRA ticket link when one exists (required by check-description).
     If there is no JIRA ticket (e.g. only a GitHub issue, or none), add the
     `No JIRA ticket` label. You may still link a GitHub issue below. -->

- [WRS-3235](https://chilipublishintranet.atlassian.net/browse/WRS-3235)

## Screenshots


[WRS-3235]: https://chilipublishintranet.atlassian.net/browse/WRS-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ